### PR TITLE
Add basic draft controller logic

### DIFF
--- a/draft/src/api.rs
+++ b/draft/src/api.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Card {
     pub name: String,
@@ -20,8 +22,36 @@ pub trait Drafter {
 #[derive(Debug)]
 pub struct DraftInfo {
     pub card_list: Vec<Card>,
-    pub num_drafters: u32,
-    pub num_packs: u32,
-    pub cards_per_pack: u32,
+    pub num_drafters: usize,
+    pub num_phases: usize,
+    pub cards_per_pack: usize,
 }
 
+// Will probably refactor this so that each Drafter keeps track of owned cards,
+// either through composition or an abstract base class, in the Python port.
+pub struct DraftState {
+    pub drafters: Vec<Box<Drafter>>,
+    pub packs: Vec<Vec<Vec<Card>>>,
+    pub owned_cards: Vec<Vec<Card>>,
+}
+
+impl DraftState {
+    pub fn new(drafters: Vec<Box<Drafter>>, packs: Vec<Vec<Vec<Card>>>) -> Self {
+        let mut owned_cards: Vec<Vec<Card>> = vec![];
+        for _d in drafters.iter() {
+            owned_cards.push(vec![]);
+        }
+
+        Self {
+            drafters,
+            packs,
+            owned_cards
+        }
+    }
+}
+
+impl fmt::Debug for DraftState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DraftState {{ packs: {:?}, owned_cards: {:?} }}", self.packs, self.owned_cards)
+    }
+}

--- a/draft/src/api.rs
+++ b/draft/src/api.rs
@@ -31,7 +31,13 @@ pub struct DraftInfo {
 // either through composition or an abstract base class, in the Python port.
 pub struct DraftState {
     pub drafters: Vec<Box<Drafter>>,
+    // The packs in a draft are organized into X phases of Y packs, each of which has Z cards.
+    // E.g. a typical draft has 3 phases, 8 packs in each (one per drafter), and 15 cards per pack.
+    // Likewise, the outermost Vec represents phase, the next nested Vec represents packs in a phase, and the
+    // innermost Vec represents the cards in a single pack.
     pub packs: Vec<Vec<Vec<Card>>>,
+    // The cards owned (previously picked) by each drafter so far. The outermost Vec represents
+    // the drafters, and the inner Vec represents the collection of cards they've picked so far in the draft.
     pub owned_cards: Vec<Vec<Card>>,
 }
 

--- a/draft/src/main.rs
+++ b/draft/src/main.rs
@@ -37,16 +37,37 @@ fn main() {
     run_draft(&draft_info, &mut draft_state);
 }
 
+// Runs through a draft with the configuration specified by draft_info and pack list in draft_state,
+// delegates picks to the drafter implementations in draft_state, and writes the picked cards to draft_state.
 fn run_draft(draft_info: &DraftInfo, draft_state: &mut DraftState) {
+
+    // "Draft phase" is commonly referred to as "Pack" by magic players, e.g. "Pack 1 pick 5".
+    // A typical draft has 3 draft phases.
     for draft_phase in 0..draft_info.num_phases {
         println!("======= draft phase: {} =======", draft_phase);
+
+        // Alternate passing directions based on phase, starting with passing left.
         let direction: i32 = if draft_phase % 2 == 0 {1} else {-1};
 
+        // "Pick index" is the "pick 1" part of "Pack 1 pick 5". In each phase, we repeat
+        // picking a card and passing until we've picked all the cards in the pack.
         for pick_index in 0..draft_info.cards_per_pack {
             println!("== pick {} ==", pick_index);
+
+            // Have each drafter make a pick.
             for drafter_index in 0..draft_info.num_drafters {
+                // We implement "passing" the packs after each pick by shifting the index of the pack
+                // that a drafter will pick from by the pick_index. We add it when passing left, and subtract
+                // when passing right (you can picture this like the packs staying in place and the drafters
+                // standing up and walking around the table).
+                // Then we apply modulus (since the packs are passed in a circle).
                 let mut current_pack_index: i32 = drafter_index as i32 + direction * pick_index as i32;
                 current_pack_index = current_pack_index % draft_info.num_drafters as i32;
+                // The mod of a negative number will remain negative, e.g. -11 mod 8 = -3, but we want to
+                // translate that into the positive equivalent to find the index into the packs, so
+                // we add num_drafters after the mod if it's a negative number. So in our example, -3
+                // would become 5. This represents starting at seat 0 and finding the drafter 3 seats to the left,
+                // which would be the drafter at seat 5.
                 if current_pack_index < 0 {
                     current_pack_index += draft_info.num_drafters as i32;
                 }

--- a/draft/src/main.rs
+++ b/draft/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(vec_remove_item)]
+
 mod random_drafter;
 mod api;
 use crate::api::*;
@@ -24,15 +26,50 @@ fn main() {
     let draft_info = create_draft_info(&list_filename);
     let mut draft_packs = create_draft_packs(&draft_info);
 
-    println!("draft packs: {:?}", draft_packs);
+    let mut drafters: Vec<Box<Drafter>> = vec![];
+    for _i in 0..draft_info.num_drafters {
+        drafters.push(Box::new(random_drafter::RandomDrafter {}));
+    }
 
-    // TODO: Implement full draft of random drafters
-    let drafter = random_drafter::RandomDrafter {};
+    let mut draft_state = DraftState::new(drafters, draft_packs);
+    println!("draft state: {:?}", draft_state);
 
-    let pack = &draft_packs[0][0];
-    let cards_owned : Vec<Card> = vec![];
+    run_draft(&draft_info, &mut draft_state);
+}
 
-    println!("Random drafter's pick: {:?}", drafter.pick(&pack, &cards_owned, &draft_info));
+fn run_draft(draft_info: &DraftInfo, draft_state: &mut DraftState) {
+    for draft_phase in 0..draft_info.num_phases {
+        println!("======= draft phase: {} =======", draft_phase);
+        let direction: i32 = if draft_phase % 2 == 0 {1} else {-1};
+
+        for pick_index in 0..draft_info.cards_per_pack {
+            println!("== pick {} ==", pick_index);
+            for drafter_index in 0..draft_info.num_drafters {
+                let mut current_pack_index: i32 = drafter_index as i32 + direction * pick_index as i32;
+                current_pack_index = current_pack_index % draft_info.num_drafters as i32;
+                if current_pack_index < 0 {
+                    current_pack_index += draft_info.num_drafters as i32;
+                }
+                let current_pack_index = current_pack_index as usize;
+                println!("Drafter {} picking from {}", drafter_index, current_pack_index);
+
+                let owned_cards= &mut (draft_state.owned_cards)[drafter_index];
+                let drafter: &Box<Drafter> = &draft_state.drafters[drafter_index];
+
+                // TODO: I think this clone shouldn't be necessary, but I couldn't figure out how to remove it,
+                // since otherwise both a mutable and immutable borrow will occur
+                let current_pack = &draft_state.packs[draft_phase][current_pack_index].clone();
+                let picked_card = drafter.pick(current_pack, owned_cards, &draft_info);
+                println!("Current pack: {:?}", current_pack);
+                println!("Picked card: {:?}\n", picked_card);
+                let picked_card = draft_state.packs[draft_phase][current_pack_index].remove_item(picked_card)
+                    .expect("could not remove card");
+                owned_cards.push(picked_card);
+            }
+        }
+    }
+
+    println!("draft state: {:?}", draft_state);
 }
 
 fn create_draft_info(cube_list_filename: &str) -> DraftInfo {
@@ -46,7 +83,7 @@ fn create_draft_info(cube_list_filename: &str) -> DraftInfo {
     DraftInfo {
         card_list: cube_list,
         num_drafters: 6,
-        num_packs: 3,
+        num_phases: 3,
         cards_per_pack: 15
     }
 }
@@ -65,13 +102,12 @@ fn create_draft_packs(draft_info: &DraftInfo) -> Vec<Vec<Vec<Card>>> {
     // innermost: a pack of cards
     let mut draft_packs: Vec<Vec<Vec<Card>>> = vec![];
 
-    for pack_index in 0..draft_info.num_packs {
+    for pack_index in 0..draft_info.num_phases {
         let mut pack_set = vec![];
 
         for seat_index in 0..draft_info.num_drafters {
             let start_index = ((pack_index * draft_info.num_drafters + seat_index) * draft_info.cards_per_pack) as usize;
             let end_index = start_index + (draft_info.cards_per_pack as usize);
-            println!("start index: {}", start_index);
             let slice: &[Card] = &shuffled_list[start_index..end_index];
             pack_set.push(slice.to_vec());
         }


### PR DESCRIPTION
This code now runs a full draft of all random picks.

In the course of writing this I decided it's probably better to have each Drafter store its owned cards, but that'd require a small refactor that I didn't feel like doing since I'd like to start porting to Python after this. Happy to add comments / improve readability / whatever, though, to make the code more usable for the next week.

You'll need to switch to nightly rust after this change: https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-nightly-rust

Also includes a minor renaming of "pack" into "draft_phases".