### PR TITLE
Add TOML draft log

### DIFF
--- a/draft_python/draft.py
+++ b/draft_python/draft.py
@@ -2,16 +2,17 @@ import sys
 from mtg_draft_ai.controller import *
 from mtg_draft_ai.api import *
 from mtg_draft_ai.brains import *
-from mtg_draft_ai import display
+from mtg_draft_ai import display, draftlog
 
 output_file = 'draft.html' if len(sys.argv) < 2 else sys.argv[1]
+draft_log_file = 'draftlog.txt' if len(sys.argv) < 3 else sys.argv[2]
 
 cube_list = read_cube_toml('cube_81183_tag_data.toml')
 
 draft_info = DraftInfo(card_list=cube_list, num_drafters=6, num_phases=3, cards_per_pack=15)
 
 gsp_factory = GreedySynergyPicker.factory(cube_list)
-drafters = [Drafter(gsp_factory.create()) for i in range(0, draft_info.num_drafters)]
+drafters = [Drafter(gsp_factory.create(), draft_info) for i in range(0, draft_info.num_drafters)]
 
 controller = DraftController.create(draft_info, drafters)
 controller.run_draft()
@@ -20,24 +21,13 @@ print('\n\nFinal state:')
 for drafter in drafters:
     print('{}\n'.format(drafter))
 
+# Write draft log - toml file recording all picks in draft
+with open(draft_log_file, 'w') as f:
+    f.write(draftlog.dumps_log(controller.drafters, draft_info))
+print('Draft log written to {}'.format(draft_log_file))
 
-output_html = """
-<style>
-card-image {
-    display: inline;
-    margin: 1px;
-}
-</style>
-"""
-
-
-i = 0
-for drafter in drafters:
-    output_html += 'Deck {}\n'.format(i)
-    for phase in range(0, 3):
-        cards_in_phase = drafter.cards_owned[phase * 15 : (phase + 1) * 15]
-        output_html += '<div>\n{}</div>\n'.format(display.cards_to_html(cards_in_phase))
-    i += 1
-
+# Write draft.html - HTML display of full draft from every seat
+html = draftlog.log_to_html(draft_log_file)
 with open(output_file, 'w') as f:
-    f.write(output_html)
+    f.write(html)
+print('Draft HTML written to {}'.format(draft_log_file))

--- a/draft_python/mtg_draft_ai/api.py
+++ b/draft_python/mtg_draft_ai/api.py
@@ -14,7 +14,6 @@ class Card:
             color_id (str): The card's color identity, as read from cubetutor. E.g. a cube owner
                 can assign R for Bomat Courier.
             tags (List[(str, str)]): List of applicable tags for this card, as read from cubetutor.
-
                 Currently, only two-part tags are supported, in the format: <Category> - <Subcategory>
                 e.g.: Lifegain - Payoff
                 Defaults to [].
@@ -32,7 +31,9 @@ class Card:
         return '{}: {}'.format(self.__class__.__name__, repr(self.__dict__))
 
     def __eq__(self, other):
-        return self.name == other.name
+        if isinstance(other, self.__class__):
+            return self.name == other.name
+        return False
 
     def __hash__(self):
         return hash(self.name)
@@ -55,14 +56,16 @@ class Card:
 class Drafter:
     """Makes picks and tracks cards already picked."""
 
-    def __init__(self, picker):
+    def __init__(self, picker, draft_info):
         """
         Args:
             picker: A Picker implementation. This Drafter instance will delegate
                 all picking decisions to picker.
         """
         self.picker = picker
+        self.draft_info = draft_info
         self.cards_owned = []
+        self.pack_history = []
 
     def pick(self, pack):
         """Picks a card by delegating to self.picker, and adds it to owned cards.
@@ -73,7 +76,10 @@ class Drafter:
         Returns:
             Card: The picked card.
         """
-        pick = self.picker.pick(pack=pack.copy(), cards_owned=self.cards_owned.copy())
+        pack_snapshot = pack.copy()
+        self.pack_history.append(pack_snapshot)
+        pick = self.picker.pick(pack=pack.copy(), cards_owned=self.cards_owned.copy(),
+                                draft_info=self.draft_info)
         if pick not in pack:
             raise ValueError('Drafter made invalid pick {} from pack {}'.format(pick, pack))
 
@@ -92,7 +98,7 @@ class Picker(abc.ABC):
     """
 
     @abc.abstractmethod
-    def pick(self, pack, cards_owned):
+    def pick(self, pack, cards_owned, draft_info):
         """Implementations should return the picked Card.
 
         Implementations do not need to modify the state of either pack or cards_owned,
@@ -101,6 +107,7 @@ class Picker(abc.ABC):
         Args:
             pack (List[Card]): The current pack to pick a card out of.
             cards_owned (List[Card]): The cards already owned.
+            draft_info (DraftInfo): Information about the draft configuration.
 
         Returns:
             Card: The picked card.
@@ -123,6 +130,9 @@ class DraftInfo:
         self.num_drafters = num_drafters
         self.num_phases = num_phases
         self.cards_per_pack = cards_per_pack
+
+    def num_cards_in_draft(self):
+        return self.num_drafters * self.num_phases * self.cards_per_pack
 
 
 class Packs:

--- a/draft_python/mtg_draft_ai/api.py
+++ b/draft_python/mtg_draft_ai/api.py
@@ -87,7 +87,7 @@ class Drafter:
         return pick
 
     def __repr__(self):
-        return 'Cards owned: {} Picker state: {}'.format([card.name for card in self.cards_owned],
+        return 'Cards owned: {} Picker state: {}'.format([str(card) for card in self.cards_owned],
                                                          self.picker)
 
 

--- a/draft_python/mtg_draft_ai/brains.py
+++ b/draft_python/mtg_draft_ai/brains.py
@@ -14,12 +14,13 @@ COLOR_TRIOS = ['WUB', 'UBR', 'BRG', 'RGW', 'GWU', 'WBR', 'URG', 'BGW', 'RWU', 'G
 class RandomPicker(Picker):
     """Makes totally random picks. Used for prototyping purposes."""
 
-    def pick(self, pack, cards_owned):
+    def pick(self, pack, cards_owned, draft_info):
         """Makes a random pick from a pack.
 
         Args:
             pack (List[Card]): The current pack to pick a card out of.
             cards_owned (List[Card]): The cards already owned.
+            draft_info (DraftInfo): Information about the draft configuration.
 
         Returns:
             Card: The picked card.
@@ -38,7 +39,7 @@ class Factory:
 
 
 _GSPRating = collections.namedtuple('Rating', ['card', 'color_combo', 'total_edges',
-                                               'new_edges', 'common_neighbors', 'default'])
+                                               'common_neighbors', 'default'])
 
 
 class GreedySynergyPicker(Picker):
@@ -81,8 +82,8 @@ class GreedySynergyPicker(Picker):
                   'common_neighbors': common_neighbors}
         return Factory(GreedySynergyPicker, kwargs)
 
-    def pick(self, pack, cards_owned):
-        ranked_candidates = self._ratings(pack, cards_owned)
+    def pick(self, pack, cards_owned, draft_info):
+        ranked_candidates = self._ratings(pack, cards_owned, draft_info)
 
         # replace full card object with just card name for more readable output
         printable_candidates = [str(_GSPRating(tup[0].name, *tup[1:])) for tup in ranked_candidates]
@@ -90,7 +91,7 @@ class GreedySynergyPicker(Picker):
 
         return pack[0] if len(ranked_candidates) == 0 else ranked_candidates[0][0]
 
-    def _ratings(self, pack, cards_owned):
+    def _ratings(self, pack, cards_owned, draft_info):
         candidates = []
 
         for color_combo in COLOR_PAIRS:
@@ -103,15 +104,13 @@ class GreedySynergyPicker(Picker):
 
                 # Number of edges in the graph for the card pool plus the candidate.
                 total_edges = len(syn_graph.edges)
-                # Number of edges added by the candidate.
-                new_edges = _num_new_edges(syn_graph, candidate)
+
                 # Number of nodes in global graph which neighbor both the candidate and the card pool.
                 # Does not count cards already in the pool as neighbors.
                 common_neighbors = len(self._card_pool_common_neighbors(on_color_cards, candidate, color_combo))
                 default = self.default_ratings[candidate]
 
-                candidates.append(_GSPRating(candidate, color_combo, total_edges, new_edges,
-                                             common_neighbors, default))
+                candidates.append(_GSPRating(candidate, color_combo, total_edges, common_neighbors, default))
 
         # Lexicographic sort of the fields in the rating tuple (excluding the card and color combo)
         candidates.sort(key=lambda tup: tup[2:], reverse=True)
@@ -122,7 +121,7 @@ class GreedySynergyPicker(Picker):
         for card in card_pool:
             neighbors.update(self.common_neighbors[candidate][card])
 
-        # Only count on-color neighbors not already in the pool
+        # Only count on-color neighbors not already in the pool, and in the color combo
         neighbors = {c for c in neighbors
                      if c not in card_pool
                      if synergy.castable(c, colors)}

--- a/draft_python/mtg_draft_ai/controller.py
+++ b/draft_python/mtg_draft_ai/controller.py
@@ -5,7 +5,7 @@ from mtg_draft_ai.api import *
 class DraftController:
     """Runs a draft by asking each drafter to pick from the right pack in the right order."""
 
-    def __init__(self, draft_info, drafters, packs):
+    def __init__(self, draft_info, drafters, packs, debug=True):
         """Basic init method which does no manipulation of its parameters.
 
         For most cases, use DraftController.create instead, which creates shuffled packs
@@ -21,9 +21,10 @@ class DraftController:
         self.draft_info = draft_info
         self.drafters = drafters
         self.packs = packs
+        self.debug = debug
 
     @staticmethod
-    def create(draft_info, drafters):
+    def create(draft_info, drafters, debug=True):
         """Creates a DraftController with shuffled packs generated from the card list.
 
         Args:
@@ -38,7 +39,7 @@ class DraftController:
             raise ValueError('Exactly {} drafters required, but got {}'
                              .format(draft_info.num_drafters, len(drafters)))
         packs = create_packs(draft_info)
-        return DraftController(draft_info=draft_info, drafters=drafters, packs=packs)
+        return DraftController(draft_info=draft_info, drafters=drafters, packs=packs, debug=debug)
 
     def run_draft(self):
         """Runs a draft by asking each drafter to pick from the right pack in the right order.
@@ -51,14 +52,14 @@ class DraftController:
         # "Draft phase" is commonly referred to as "Pack" by magic players, e.g. "Pack 1 pick 5".
         # A typical draft has 3 draft phases.
         for phase in range(0, self.draft_info.num_phases):
-            print('====== Phase {} ======'.format(phase))
+            self._debug('====== Phase {} ======'.format(phase))
             # Alternate passing directions based on phase, starting with passing left.
             direction = 1 if phase % 2 == 0 else -1
 
             # "Pick index" is the "pick 1" part of "Pack 1 pick 5". In each phase, we repeat
             # picking a card and passing until we've picked all the cards in the pack.
             for pick in range(0, self.draft_info.cards_per_pack):
-                print('== Pick {} =='.format(pick))
+                self._debug('== Pick {} =='.format(pick))
 
                 # Have each drafter make a pick.
                 for drafter in range(0, self.draft_info.num_drafters):
@@ -77,14 +78,17 @@ class DraftController:
                     if pack_index < 0:
                         pack_index += self.draft_info.num_drafters
 
-                    print('Drafter {} pick {}'.format(drafter, pick))
+                    self._debug('Drafter {} pick {}'.format(drafter, pick))
                     pack = self.packs.get_pack(phase=phase, starting_seat=pack_index)
-                    print('Pack: {}'.format([str(card) for card in pack]))
-                    print('Cards Owned: {}'.format([str(card) for card in self.drafters[drafter].cards_owned]))
+                    self._debug('Pack: {}'.format([str(card) for card in pack]))
+                    self._debug('Cards Owned: {}'.format([str(card) for card in self.drafters[drafter].cards_owned]))
                     picked = self.drafters[drafter].pick(pack)
-                    print('Picked: {}\n'.format(picked))
+                    self._debug('Picked: {}\n'.format(picked))
                     pack.remove(picked)
 
+    def _debug(self, message):
+        if self.debug:
+            print(message)
 
 def create_packs(draft_info):
     """Creates a collection of shuffled packs to be used for one draft.

--- a/draft_python/mtg_draft_ai/controller.py
+++ b/draft_python/mtg_draft_ai/controller.py
@@ -17,6 +17,7 @@ class DraftController:
             drafters (list of Drafter): The Drafters, which may have different Picker
                 implementations.
             packs (Packs): The Packs to use for this draft. Should already be initialized.
+            debug (bool): Whether to print debugging info on the draft. Defaults to True.
         """
         self.draft_info = draft_info
         self.drafters = drafters

--- a/draft_python/mtg_draft_ai/display.py
+++ b/draft_python/mtg_draft_ai/display.py
@@ -3,7 +3,7 @@
 import urllib
 
 
-def image_html(card_name, width=146, height=204):
+def image_html(card_name, width=146, height=204, highlighted=False):
     """Formats an img tag for the scryfall card image.
 
     Args:
@@ -16,8 +16,12 @@ def image_html(card_name, width=146, height=204):
     """
     url_prefix = 'https://api.scryfall.com/cards/named?'
     params = urllib.parse.urlencode({'format': 'image', 'exact': card_name})
-    return '<img src="{}{}" width="{}" height="{}" class="card-image" />'.format(url_prefix,
-                                                                                 params, width, height)
+    css_class = 'card-image'
+    if highlighted:
+        css_class += ' highlight'
+
+    return '<img src="{}{}" width="{}" height="{}" class="{}" />'.format(url_prefix, params,
+                                                                         width, height, css_class)
 
 
 def cards_to_html(cards):
@@ -25,6 +29,27 @@ def cards_to_html(cards):
     return '\n'.join([image_html(card.name) for card in cards])
 
 
-def card_names_to_html(card_names):
+def card_names_to_html(card_names, highlighted=None):
     """Returns HTML for scryfall images for a list of card names. Images are all in one row."""
-    return '\n'.join([image_html(name) for name in card_names])
+    return '\n'.join([image_html(name, highlighted=(name == highlighted)) for name in card_names])
+
+
+def default_style():
+    return """
+    <style>
+    card-image {
+        display: inline;
+        margin: 1px;
+    }
+    .highlight {
+        border-width: 10px;
+        border-color: red;
+        border-style: solid;
+    }
+    .pack {
+        border-color: black;   
+        border-style: solid;
+        padding: 5px;
+    }
+    </style>
+"""

--- a/draft_python/mtg_draft_ai/draftlog.py
+++ b/draft_python/mtg_draft_ai/draftlog.py
@@ -4,6 +4,15 @@ from mtg_draft_ai.api import DraftInfo, Drafter
 
 
 def dumps_log(drafters, draft_info):
+    """Writes pick history of drafters into a toml log file.
+
+    Args:
+        drafters (List[Drafter]): Drafters to create log for.
+        draft_info (DraftInfo): Draft config to record.
+
+    Returns:
+        str: TOML string containing every pick for every drafter, as well as the draft info.
+    """
     full_draft = []
     i = 0
     for d in drafters:
@@ -18,6 +27,16 @@ def dumps_log(drafters, draft_info):
 
 
 def load_drafters_from_log(log_file, card_list=None):
+    """Returns a list of drafters, with pick history, reconstructed from log file.
+
+    Args:
+        log_file: File-like object to load the log from.
+        card_list (List[Card]): Optional - specify in order to return full Card objects instead of just names.
+
+    Returns:
+        By default, returned pick history contains card names only. If card_list is provided,
+        contains full card objects instead.
+    """
     log_obj = toml.load(log_file)
 
     draft_info = DraftInfo(card_list=card_list, **log_obj['draft_info'])
@@ -43,6 +62,8 @@ def load_drafters_from_log(log_file, card_list=None):
 
 
 def log_to_html(log_file):
+    """Outputs HTML visualization of a draft from the given log file."""
+
     drafters = load_drafters_from_log(log_file)
 
     html = default_style()

--- a/draft_python/mtg_draft_ai/draftlog.py
+++ b/draft_python/mtg_draft_ai/draftlog.py
@@ -1,0 +1,61 @@
+import toml
+from mtg_draft_ai.display import card_names_to_html, default_style
+from mtg_draft_ai.api import DraftInfo, Drafter
+
+
+def dumps_log(drafters, draft_info):
+    full_draft = []
+    i = 0
+    for d in drafters:
+        picks = [{'pack': [c.name for c in pack], 'pick': pick.name} for pack, pick in zip(d.pack_history, d.cards_owned)]
+        full_draft.append({'drafter': i, 'picks': picks})
+        i += 1
+
+    draft_info_dict = draft_info.__dict__
+    draft_info_dict.pop('card_list')
+
+    return toml.dumps({'draft_info': draft_info_dict, 'full_draft': full_draft})
+
+
+def load_drafters_from_log(log_filename, card_list=None):
+    with open(log_filename, 'r') as f:
+        log_obj = toml.load(f)
+
+    draft_info = DraftInfo(card_list=card_list, **log_obj['draft_info'])
+
+    if card_list:
+        cards_by_name = {c.name: c for c in card_list}
+
+    drafters = []
+
+    for drafter_picks in log_obj['full_draft']:
+        drafter = Drafter(picker=None, draft_info=draft_info)
+        drafters.append(drafter)
+
+        for pick in drafter_picks['picks']:
+            drafter.cards_owned.append(pick['pick'])
+            drafter.pack_history.append(pick['pack'])
+
+        if card_list:
+            drafter.cards_owned = [cards_by_name[n] for n in drafter.cards_owned]
+            drafter.pack_history = [[cards_by_name[n] for n in p] for p in drafter.pack_history]
+
+    return drafters
+
+
+def log_to_html(log_filename):
+    drafters = load_drafters_from_log(log_filename)
+
+    html = default_style()
+
+    i = 0
+    for drafter in drafters:
+        html += 'Drafter {}\n'.format(i)
+        for pack, pick in zip(drafter.pack_history, drafter.cards_owned):
+            html += '<div class="pack">\n{}</div>\n'.format(card_names_to_html(pack, highlighted=pick))
+
+        html += 'Drafter {} final pool\n'.format(i)
+        html += '<div class>\n{}</div>\n'.format(card_names_to_html(drafter.cards_owned))
+        i += 1
+
+    return html

--- a/draft_python/mtg_draft_ai/draftlog.py
+++ b/draft_python/mtg_draft_ai/draftlog.py
@@ -17,9 +17,8 @@ def dumps_log(drafters, draft_info):
     return toml.dumps({'draft_info': draft_info_dict, 'full_draft': full_draft})
 
 
-def load_drafters_from_log(log_filename, card_list=None):
-    with open(log_filename, 'r') as f:
-        log_obj = toml.load(f)
+def load_drafters_from_log(log_file, card_list=None):
+    log_obj = toml.load(log_file)
 
     draft_info = DraftInfo(card_list=card_list, **log_obj['draft_info'])
 
@@ -43,8 +42,8 @@ def load_drafters_from_log(log_filename, card_list=None):
     return drafters
 
 
-def log_to_html(log_filename):
-    drafters = load_drafters_from_log(log_filename)
+def log_to_html(log_file):
+    drafters = load_drafters_from_log(log_file)
 
     html = default_style()
 

--- a/draft_python/tests/data/cube_81183_tag_data.toml
+++ b/draft_python/tests/data/cube_81183_tag_data.toml
@@ -1,0 +1,2255 @@
+["Abhorrent Overlord"]
+mana_cost = ["5","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler"]
+
+["Abzan Battle Priest"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Counters - Payoff","Keyword","Lifegain - Enabler","Counters - Enabler"]
+
+["Accorder Paladin"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Tokens - Payoff","Keyword"]
+
+["Adarkar Wastes"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Adeliz, the Cinder Wind"]
+mana_cost = ["1","U","R"]
+color_identity = "UR"
+types = ["creature"]
+tags = ["Spells - Payoff","Wizards - Payoff","Wizards - Enabler"]
+
+["Ajani's Pridemate"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Lifegain - Payoff"]
+
+["Akroan Crusader"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Heroic - Payoff","Keyword"]
+
+["Anafenza, Kin-Tree Spirit"]
+mana_cost = ["W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Counters - Enabler","Keyword","Spirits - Enabler","ETB - Enabler"]
+
+["Anax and Cymede"]
+mana_cost = ["1","W","R"]
+color_identity = "RW"
+types = ["creature"]
+tags = ["Signpost","Heroic - Payoff","Keyword"]
+
+["Angel of Flight Alabaster"]
+mana_cost = ["4","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Spirits - Payoff"]
+
+["Angelic Gift"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Heroic - Enabler"]
+
+["Anowon, the Ruin Sage"]
+mana_cost = ["3","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Vampires - Enabler","Vampires - Payoff","Sacrifice - Payoff","Signpost"]
+
+["Arcbond"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Spells - Enabler"]
+
+["Arena Athlete"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Heroic - Payoff","Keyword"]
+
+["Armorcraft Judge"]
+mana_cost = ["3","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Signpost","Counters - Payoff","ETB - Enabler","Card Draw"]
+
+["Artificer's Assistant"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Artifacts - Payoff","Ninjutsu - Enabler"]
+
+["Asylum Visitor"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Keyword","Vampires - Enabler","Wizards - Enabler","Card Draw","Madness/Hellbent - Payoff"]
+
+["Augury Owl"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["ETB - Enabler","Ninjutsu - Enabler"]
+
+["Ayli, Eternal Pilgrim"]
+mana_cost = ["W","B"]
+color_identity = "BW"
+types = ["creature"]
+tags = ["Signpost","Lifegain - Enabler","Lifegain - Payoff","Higher Toughness"]
+
+["Azami, Lady of Scrolls"]
+mana_cost = ["2","U","U","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Signpost","Wizards - Payoff","Wizards - Enabler","Card Draw"]
+
+["Azorius Herald"]
+mana_cost = ["2","W"]
+color_identity = "UW"
+types = ["creature"]
+tags = ["Spirits - Enabler","Lifegain - Enabler","ETB - Enabler"]
+
+["Azorius Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Azra Oddsmaker"]
+mana_cost = ["1","B","R"]
+color_identity = "BR"
+types = ["creature"]
+tags = ["Card Draw","Madness/Hellbent - Enabler"]
+
+["Banisher Priest"]
+mana_cost = ["1","W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Removal","ETB - Enabler"]
+
+["Banishing Light"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Removal"]
+
+["Battlefield Forge"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Bedlam Reveler"]
+mana_cost = ["6","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword","Card Draw"]
+
+["Bile Blight"]
+mana_cost = ["B","B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Removal"]
+
+["Birds of Paradise"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Ninjutsu - Enabler"]
+
+["Bishop of Rebirth"]
+mana_cost = ["3","W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Higher Toughness","Vampires - Enabler"]
+
+["Blade of the Bloodchief"]
+mana_cost = ["1"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Counters - Enabler","Sacrifice - Payoff","Vampires - Payoff","Artifacts - Enabler"]
+
+["Blighted Gorge"]
+mana_cost = []
+color_identity = "R"
+types = ["land"]
+tags = ["Land Graveyard - Enabler"]
+
+["Blood Artist"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Vampires - Enabler","Lifegain - Enabler"]
+
+["Bloodfell Caves"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Bloodhall Priest"]
+mana_cost = ["2","B","R"]
+color_identity = "BR"
+types = ["creature"]
+tags = ["Signpost","Big","Keyword","Vampires - Enabler","Madness/Hellbent - Payoff"]
+
+["Bloodline Necromancer"]
+mana_cost = ["4","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Payoff","Vampires - Enabler","Wizards - Payoff","Wizards - Enabler"]
+
+["Bloodrage Brawler"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Madness/Hellbent - Enabler"]
+
+["Bloodsoaked Champion"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Enabler","Keyword"]
+
+["Bloodspore Thrinax"]
+mana_cost = ["2","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Tokens - Payoff","Keyword","Sacrifice - Payoff"]
+
+["Blossoming Defense"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["instant"]
+tags = ["Trick","Heroic - Enabler"]
+
+["Blossoming Sands"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Bomat Courier"]
+mana_cost = ["1"]
+color_identity = "R"
+types = ["artifact","creature"]
+tags = ["Madness/Hellbent - Enabler","Artifacts - Enabler"]
+
+["Bone Picker"]
+mana_cost = ["3","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Ninjutsu - Enabler"]
+
+["Bone Splinters"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = ["Removal","Sacrifice - Payoff"]
+
+["Boros Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Bound by Moonsilver"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Removal","Keyword","Heroic - Enabler"]
+
+["Bounding Krasis"]
+mana_cost = ["1","U","G"]
+color_identity = "GU"
+types = ["creature"]
+tags = ["Flash - Threat"]
+
+["Brago, King Eternal"]
+mana_cost = ["2","W","U"]
+color_identity = "UW"
+types = ["creature"]
+tags = ["Signpost","ETB - Payoff","Spirits - Enabler","Higher Toughness"]
+
+["Brimstone Volley"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Removal","Keyword","Spells - Enabler"]
+
+["Brion Stoutarm"]
+mana_cost = ["2","R","W"]
+color_identity = "RW"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Big"]
+
+["Brittle Effigy"]
+mana_cost = ["1"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Removal","Artifacts - Enabler"]
+
+["Brushland"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Buried Ruin"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = ["Land Graveyard - Enabler","Artifacts - Payoff"]
+
+["Call to the Feast"]
+mana_cost = ["2","W","B"]
+color_identity = "BW"
+types = ["sorcery"]
+tags = ["Tokens - Enabler","Lifegain - Enabler","Vampires - Enabler"]
+
+["Cathartic Reunion"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["sorcery"]
+tags = ["Graveyard - Enabler","Spells - Enabler","Madness/Hellbent - Enabler"]
+
+["Cavern Harpy"]
+mana_cost = ["U","B"]
+color_identity = "BU"
+types = ["creature"]
+tags = ["ETB - Payoff","Ninjutsu - Enabler"]
+
+["Caves of Koilos"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Chart a Course"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["sorcery"]
+tags = ["Graveyard - Enabler","Keyword","Card Draw","Spells - Enabler","Madness/Hellbent - Enabler"]
+
+["Clifftop Retreat"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Cloudblazer"]
+mana_cost = ["3","W","U"]
+color_identity = "UW"
+types = ["creature"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Card Draw"]
+
+["Cloudfin Raptor"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Counters - Enabler","Keyword","Ninjutsu - Enabler"]
+
+["Collateral Damage"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Sacrifice - Payoff","Removal","Spells - Enabler"]
+
+["Commune with the Gods"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["sorcery"]
+tags = ["Graveyard - Enabler"]
+
+["Countryside Crusher"]
+mana_cost = ["1","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Land Graveyard - Payoff","Land Graveyard - Enabler","Big"]
+
+["Crawling Sensation"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["enchantment"]
+tags = ["Graveyard - Enabler","Land Graveyard - Payoff"]
+
+["Crested Herdcaller"]
+mana_cost = ["3","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","ETB - Enabler"]
+
+["Crested Sunmare"]
+mana_cost = ["3","W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Lifegain - Payoff","Big"]
+
+["Crovax the Cursed"]
+mana_cost = ["2","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Signpost","Sacrifice - Payoff","Counters - Enabler","Big","Vampires - Enabler"]
+
+["Crusader of Odric"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Tokens - Payoff","Big"]
+
+["Crush of Tentacles"]
+mana_cost = ["4","U","U"]
+color_identity = "U"
+types = ["sorcery"]
+tags = ["Big","Keyword","ETB - Payoff"]
+
+["Crux of Fate"]
+mana_cost = ["3","B","B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = []
+
+["Cryptic Serpent"]
+mana_cost = ["5","U","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Spells - Payoff"]
+
+["Cultivator's Caravan"]
+mana_cost = ["3"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Big","Artifacts - Enabler"]
+
+["Curious Obsession"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Heroic - Enabler","Card Draw"]
+
+["Daring Archaeologist"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Artifacts - Payoff","Big","Keyword","ETB - Enabler"]
+
+["Dark-Dweller Oracle"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Sacrifice - Payoff"]
+
+["Deadbridge Chant"]
+mana_cost = ["4","B","G"]
+color_identity = "BG"
+types = ["enchantment"]
+tags = ["Signpost","Graveyard - Enabler","Card Draw"]
+
+["Deadeye Harpooner"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["ETB - Enabler","Removal"]
+
+["Devoted Druid"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = []
+
+["Dimir Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Dinrova Horror"]
+mana_cost = ["4","U","B"]
+color_identity = "BU"
+types = ["creature"]
+tags = ["ETB - Enabler","Bounce"]
+
+["Dismal Backwater"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Dismissive Pyromancer"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Removal","Wizards - Enabler","Madness/Hellbent - Enabler","Graveyard - Enabler"]
+
+["Disperse"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Bounce","Spells - Enabler"]
+
+["Dissolve"]
+mana_cost = ["1","U","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Flash - Counterspell","Spells - Enabler"]
+
+["Dive Down"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Trick","Heroic - Enabler","Spells - Enabler"]
+
+["Dragon Mantle"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["enchantment"]
+tags = ["Heroic - Enabler"]
+
+["Dragonskull Summit"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Drake Haven"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Signpost","Madness/Hellbent - Payoff"]
+
+["Drowned Catacomb"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Dusk Legion Zealot"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["ETB - Enabler","Vampires - Enabler"]
+
+["Embodiment of Fury"]
+mana_cost = ["3","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Land Graveyard - Enabler","Landfall - Payoff","Keyword"]
+
+["Enthralling Victor"]
+mana_cost = ["3","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Sacrifice - Enabler","ETB - Enabler"]
+
+["Epiphany at the Drownyard"]
+mana_cost = ["X","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler"]
+
+["Essence Flux"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Trick","Spirits - Payoff","Spells - Enabler"]
+
+["Experiment One"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Keyword"]
+
+["Fa'adiyah Seer"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Landfall - Enabler","Graveyard - Enabler","Madness/Hellbent - Enabler"]
+
+["Fall of the Titans"]
+mana_cost = ["X","X","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Removal","Heroic - Enabler","Keyword","Spells - Enabler"]
+
+["Familiar's Ruse"]
+mana_cost = ["U","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Flash - Counterspell"]
+
+["Favored Hoplite"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Heroic - Payoff","Higher Toughness","Keyword"]
+
+["Felidar Sovereign"]
+mana_cost = ["4","W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Lifegain - Payoff","Signpost","Higher Toughness"]
+
+["Fettergeist"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Higher Toughness","Spirits - Enabler","Ninjutsu - Enabler"]
+
+["Fiery Temper"]
+mana_cost = ["1","R","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Keyword","Spells - Enabler","Madness/Hellbent - Payoff"]
+
+["Filigree Familiar"]
+mana_cost = ["3"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Lifegain - Enabler","Artifacts - Enabler"]
+
+["Fists of Ironwood"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["enchantment"]
+tags = ["Tokens - Enabler","Heroic - Enabler"]
+
+["Flameblade Adept"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Madness/Hellbent - Payoff"]
+
+["Fortune's Favor"]
+mana_cost = ["3","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler"]
+
+["Foundry of the Consuls"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler"]
+
+["Gallant Cavalry"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["ETB - Enabler","Tokens - Enabler"]
+
+["Gather the Townsfolk"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["sorcery"]
+tags = ["Tokens - Enabler","Keyword","Spells - Enabler"]
+
+["Generator Servant"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = []
+
+["Generous Patron"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword","ETB - Enabler","Card Draw"]
+
+["Genesis Wave"]
+mana_cost = ["X","G","G","G"]
+color_identity = "G"
+types = ["sorcery"]
+tags = ["Big"]
+
+["Ghitu Lavarunner"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Wizards - Enabler"]
+
+["Ghoultree"]
+mana_cost = ["7","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Signpost","Graveyard - Payoff","Big"]
+
+["Gideon's Reproach"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["instant"]
+tags = ["Removal","Spells - Enabler"]
+
+["Gird for Battle"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["sorcery"]
+tags = ["Heroic - Enabler","Counters - Enabler","Spells - Enabler"]
+
+["Glacial Fortress"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Glint-Nest Crane"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Artifacts - Payoff","Higher Toughness","ETB - Enabler","Ninjutsu - Enabler"]
+
+["Goblin Assault"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["enchantment"]
+tags = ["Tokens - Enabler","Sacrifice - Enabler"]
+
+["Goblin Clearcutter"]
+mana_cost = ["3","R"]
+color_identity = "GR"
+types = ["creature"]
+tags = ["Land Graveyard - Enabler"]
+
+["Goblin Instigator"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Sacrifice - Enabler","Tokens - Enabler","ETB - Enabler"]
+
+["Goblin Welder"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Signpost","Artifacts - Payoff"]
+
+["Golgari Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Gonti, Lord of Luxury"]
+mana_cost = ["2","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Higher Toughness","ETB - Enabler"]
+
+["Grab the Reins"]
+mana_cost = ["3","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Keyword","Spells - Enabler"]
+
+["Graveyard Marshal"]
+mana_cost = ["B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Signpost"]
+
+["Grazing Gladehart"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Landfall - Payoff"]
+
+["Greenwarden of Murasa"]
+mana_cost = ["4","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Big","ETB - Enabler"]
+
+["Gruesome Menagerie"]
+mana_cost = ["3","B","B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = ["Graveyard - Payoff"]
+
+["Gruul Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Gyre Sage"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Higher Toughness","Keyword"]
+
+["Harbinger of the Tides"]
+mana_cost = ["U","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Bounce","ETB - Enabler","Wizards - Enabler","Flash - Threat"]
+
+["Hardened Scales"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["enchantment"]
+tags = ["Counters - Payoff","Signpost"]
+
+["Harm's Way"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["instant"]
+tags = ["Removal","Heroic - Enabler","Spells - Enabler"]
+
+["Harvest Pyre"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Removal","Graveyard - Payoff","Spells - Enabler"]
+
+["Haunted Dead"]
+mana_cost = ["3","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Tokens - Enabler","Graveyard - Payoff","Spirits - Enabler","ETB - Enabler","Madness/Hellbent - Enabler","Sacrifice - Enabler"]
+
+["Hedron Archive"]
+mana_cost = ["4"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Card Draw","Artifacts - Enabler"]
+
+["Heir of Falkenrath"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Keyword","Vampires - Enabler","Madness/Hellbent - Enabler"]
+
+["Heir of the Wilds"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Keyword"]
+
+["Hermit Druid"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Enabler","Landfall - Enabler","Land Graveyard - Enabler"]
+
+["Higure, the Still Wind"]
+mana_cost = ["3","U","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff","Signpost","Ninjutsu - Enabler"]
+
+["Hinterland Harbor"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Hollowhenge Spirit"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Spirits - Enabler","Flash - Threat"]
+
+["Hostile Desert"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = ["Land Graveyard - Payoff"]
+
+["Illusionist's Stratagem"]
+mana_cost = ["3","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["ETB - Payoff","Spells - Enabler"]
+
+["Incendiary Flow"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["sorcery"]
+tags = ["Removal","Spells - Enabler"]
+
+["Indulgent Aristocrat"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Lifegain - Enabler","Counters - Enabler","Vampires - Enabler","Vampires - Payoff"]
+
+["Inspiring Cleric"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Enabler"]
+
+["Isolated Chapel"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Izzet Chemister"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Spells - Payoff","Graveyard - Payoff","Signpost","Higher Toughness","Wizards - Enabler"]
+
+["Izzet Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Jeskai Ascendancy"]
+mana_cost = ["U","R","W"]
+color_identity = "RUW"
+types = ["enchantment"]
+tags = ["Signpost","Spells - Payoff","Tokens - Payoff","Madness/Hellbent - Enabler"]
+
+["Jori En, Ruin Diver"]
+mana_cost = ["1","U","R"]
+color_identity = "UR"
+types = ["creature"]
+tags = ["Higher Toughness","Wizards - Enabler","Card Draw"]
+
+["Jungle Hollow"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Juniper Order Ranger"]
+mana_cost = ["3","G","W"]
+color_identity = "GW"
+types = ["creature"]
+tags = ["Counters - Enabler","Tokens - Payoff","ETB - Enabler","Higher Toughness"]
+
+["Kalastria Highborn"]
+mana_cost = ["B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Vampires - Enabler","Vampires - Payoff"]
+
+["Kami of Ancient Law"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Spirits - Enabler"]
+
+["Kari Zev, Skyship Raider"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Sacrifice - Enabler","Tokens - Enabler","Higher Toughness"]
+
+["Karn, Silver Golem"]
+mana_cost = ["5"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Artifacts - Payoff","Signpost","Higher Toughness","Artifacts - Enabler"]
+
+["Karplusan Forest"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Kessig Cagebreakers"]
+mana_cost = ["4","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Signpost","Higher Toughness","Big"]
+
+["Key to the City"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Madness/Hellbent - Enabler","Artifacts - Enabler","Ninjutsu - Enabler"]
+
+["Killing Glare"]
+mana_cost = ["X","B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Removal"]
+
+["Kindly Stranger"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Removal","Higher Toughness","Keyword","Madness/Hellbent - Payoff"]
+
+["Kiri-Onna"]
+mana_cost = ["4","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Spirits - Enabler","ETB - Enabler","Bounce"]
+
+["Kitesail Freebooter"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Ninjutsu - Enabler"]
+
+["Lambholt Elder"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Flash - Threat"]
+
+["Lantern Kami"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Spirits - Enabler","Ninjutsu - Enabler"]
+
+["Launch the Fleet"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["sorcery"]
+tags = ["Tokens - Enabler","Tokens - Payoff","Keyword","Spells - Enabler"]
+
+["Lightning Helix"]
+mana_cost = ["R","W"]
+color_identity = "RW"
+types = ["instant"]
+tags = ["Removal","Lifegain - Enabler","Spells - Enabler"]
+
+["Liliana's Specter"]
+mana_cost = ["1","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["ETB - Enabler","Ninjutsu - Enabler"]
+
+["Llanowar Elves"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["creature"]
+tags = []
+
+["Llanowar Wastes"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Lone Rider"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Lifegain - Payoff","Lifegain - Enabler","Keyword"]
+
+["Loyal Pegasus"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Ninjutsu - Enabler"]
+
+["Ludevic's Test Subject"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Big","Flash - Threat"]
+
+["Magma Burst"]
+mana_cost = ["3","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Keyword","Land Graveyard - Enabler","Removal","Spells - Enabler"]
+
+["Magmatic Force"]
+mana_cost = ["5","R","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Big","Reanimator - Payoff"]
+
+["Magmatic Insight"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["sorcery"]
+tags = ["Land Graveyard - Enabler","Spells - Enabler"]
+
+["Magmaw"]
+mana_cost = ["3","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Signpost"]
+
+["Magus of the Scroll"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Removal","Wizards - Enabler","Madness/Hellbent - Payoff"]
+
+["Magus of the Wheel"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Graveyard - Enabler","Wizards - Enabler","Madness/Hellbent - Enabler"]
+
+["Mana Leak"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Flash - Counterspell","Spells - Enabler"]
+
+["Martial Glory"]
+mana_cost = ["W","R"]
+color_identity = "RW"
+types = ["instant"]
+tags = ["Trick","Heroic - Enabler","Spells - Enabler"]
+
+["Martyr of Dusk"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Sacrifice - Enabler","Lifegain - Enabler","Vampires - Enabler"]
+
+["Maverick Thopterist"]
+mana_cost = ["3","U","R"]
+color_identity = "UR"
+types = ["creature"]
+tags = ["Signpost","Tokens - Enabler","Artifacts - Enabler","Artifacts - Payoff","Keyword","ETB - Enabler"]
+
+["Mavren Fein, Dusk Apostle"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Tokens - Enabler","Lifegain - Enabler","Signpost","Vampires - Enabler","Vampires - Payoff"]
+
+["Memorial to Unity"]
+mana_cost = []
+color_identity = "G"
+types = ["land"]
+tags = ["Land Graveyard - Enabler"]
+
+["Mercy Killing"]
+mana_cost = ["2","GW"]
+color_identity = "GW"
+types = ["instant"]
+tags = ["Removal","Tokens - Enabler","Spells - Enabler"]
+
+["Metallic Mimic"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Counters - Enabler","Tokens - Payoff","Artifacts - Enabler"]
+
+["Metalwork Colossus"]
+mana_cost = ["11"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Signpost","Artifacts - Payoff","Big","Artifacts - Enabler"]
+
+["Midnight Oil"]
+mana_cost = ["2","B","B"]
+color_identity = "B"
+types = ["enchantment"]
+tags = ["Card Draw"]
+
+["Might of the Masses"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["instant"]
+tags = ["Trick","Tokens - Payoff","Heroic - Enabler"]
+
+["Mikaeus, the Lunarch"]
+mana_cost = ["X","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Counters - Enabler","Tokens - Payoff","Signpost","Big"]
+
+["Militia Bugler"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Higher Toughness","ETB - Enabler"]
+
+["Mina and Denn, Wildborn"]
+mana_cost = ["2","R","G"]
+color_identity = "GR"
+types = ["creature"]
+tags = ["Landfall - Enabler","Big"]
+
+["Mindless Automaton"]
+mana_cost = ["4"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Counters - Enabler","Counters - Payoff","Madness/Hellbent - Enabler","Artifacts - Enabler"]
+
+["Mindstorm Crown"]
+mana_cost = ["3"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Card Draw","Madness/Hellbent - Payoff","Artifacts - Enabler"]
+
+["Mirror Mockery"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Removal","ETB - Payoff"]
+
+["Mistblade Shinobi"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff"]
+
+["Molten Vortex"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["enchantment"]
+tags = ["Land Graveyard - Enabler"]
+
+["Murderous Cut"]
+mana_cost = ["4","B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Removal","Graveyard - Payoff","Keyword"]
+
+["Mystic Snake"]
+mana_cost = ["1","G","U","U"]
+color_identity = "GU"
+types = ["creature"]
+tags = ["Signpost","Flash - Counterspell"]
+
+["Naru Meha, Master Wizard"]
+mana_cost = ["2","U","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Signpost","Wizards - Payoff","Spells - Payoff","ETB - Enabler","Wizards - Enabler","Flash - Threat"]
+
+["Nearheath Chaplain"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Tokens - Enabler","Spirits - Enabler"]
+
+["Nebelgast Herald"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Spirits - Payoff","Spirits - Enabler","Flash - Threat","Ninjutsu - Enabler"]
+
+["Necropolis Fiend"]
+mana_cost = ["7","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Signpost","Graveyard - Payoff","Higher Toughness","Big","Keyword"]
+
+["Negate"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Flash - Counterspell","Spells - Enabler"]
+
+["Neheb, the Eternal"]
+mana_cost = ["3","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Higher Toughness","Big","Keyword"]
+
+["Niblis of the Urn"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Spirits - Enabler","Ninjutsu - Enabler"]
+
+["Ninja of the Deep Hours"]
+mana_cost = ["3","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff"]
+
+["Nyx Weaver"]
+mana_cost = ["1","B","G"]
+color_identity = "BG"
+types = ["enchantment","creature"]
+tags = ["Graveyard - Enabler","Graveyard - Payoff","Signpost","Higher Toughness"]
+
+["Oathsworn Vampire"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Lifegain - Payoff","Vampires - Enabler"]
+
+["Ochran Assassin"]
+mana_cost = ["1","B","G"]
+color_identity = "BG"
+types = ["creature"]
+tags = ["Removal"]
+
+["Ogre Battledriver"]
+mana_cost = ["2","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Signpost","Tokens - Payoff"]
+
+["Okiba-Gang Shinobi"]
+mana_cost = ["3","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff"]
+
+["Omnath, Locus of Rage"]
+mana_cost = ["3","R","R","G","G"]
+color_identity = "GR"
+types = ["creature"]
+tags = ["Reanimator - Payoff","Big","Landfall - Payoff","Keyword"]
+
+["Oppressive Rays"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Removal"]
+
+["Opt"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Spells - Enabler"]
+
+["Oracle of Mul Daya"]
+mana_cost = ["3","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Landfall - Enabler"]
+
+["Oracle's Vault"]
+mana_cost = ["4"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Card Draw","Artifacts - Enabler"]
+
+["Ordeal of Heliod"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Heroic - Enabler","Lifegain - Enabler","Counters - Enabler"]
+
+["Ordeal of Thassa"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw"]
+
+["Orzhov Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Outnumber"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Removal","Tokens - Payoff","Spells - Enabler"]
+
+["Pacification Array"]
+mana_cost = ["1"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Removal","Artifacts - Enabler"]
+
+["Pacifism"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Removal"]
+
+["Pack Guardian"]
+mana_cost = ["2","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Land Graveyard - Enabler","Spirits - Enabler","Flash - Threat"]
+
+["Palladium Myr"]
+mana_cost = ["3"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Artifacts - Enabler"]
+
+["Panharmonicon"]
+mana_cost = ["4"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Signpost","ETB - Payoff","Artifacts - Enabler"]
+
+["Path of Bravery"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Lifegain - Enabler","Lifegain - Payoff","Tokens - Payoff"]
+
+["Path of Discovery"]
+mana_cost = ["3","G"]
+color_identity = "G"
+types = ["enchantment"]
+tags = ["Counters - Enabler","Graveyard - Enabler","Landfall - Enabler","Keyword","Tokens - Payoff"]
+
+["Peel from Reality"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["ETB - Payoff","Bounce","Spells - Enabler"]
+
+["Perilous Myr"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Removal","Sacrifice - Enabler","Artifacts - Enabler"]
+
+["Phalanx Leader"]
+mana_cost = ["W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Heroic - Payoff","Counters - Enabler","Keyword"]
+
+["Phantom Nomad"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Counters - Enabler","Spirits - Enabler"]
+
+["Pianna, Nomad Captain"]
+mana_cost = ["1","W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Tokens - Payoff","Signpost"]
+
+["Pilfering Imp"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Ninjutsu - Enabler"]
+
+["Piston Sledge"]
+mana_cost = ["3"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Payoff","Keyword","Artifacts - Enabler"]
+
+["Pongify"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Removal","Trick","Flash - Threat","Spells - Enabler"]
+
+["Possessed Skaab"]
+mana_cost = ["3","U","B"]
+color_identity = "BU"
+types = ["creature"]
+tags = ["ETB - Enabler"]
+
+["Precognition Field"]
+mana_cost = ["3","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Spells - Payoff","Signpost","Card Draw"]
+
+["Presence of Gond"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["enchantment"]
+tags = ["Tokens - Enabler","Heroic - Enabler"]
+
+["Prey Upon"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["sorcery"]
+tags = ["Removal","Heroic - Enabler"]
+
+["Prophet of Kruphix"]
+mana_cost = ["3","U","G"]
+color_identity = "GU"
+types = ["creature"]
+tags = ["Signpost","Higher Toughness","Wizards - Enabler","Flash - Threat"]
+
+["Prophetic Prism"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Pyrite Spellbomb"]
+mana_cost = ["1"]
+color_identity = "R"
+types = ["artifact"]
+tags = ["Removal","Artifacts - Enabler"]
+
+["Pyromancer's Goggles"]
+mana_cost = ["5"]
+color_identity = "R"
+types = ["artifact"]
+tags = ["Signpost","Spells - Payoff","Artifacts - Enabler"]
+
+["Quickling"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["ETB - Payoff","Ninjutsu - Enabler","Flash - Threat"]
+
+["Rakdos Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Ramunap Excavator"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Land Graveyard - Payoff","Landfall - Enabler","Higher Toughness"]
+
+["Rattlechains"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Spirits - Payoff","Spirits - Enabler","Flash - Threat","Ninjutsu - Enabler"]
+
+["Ravenous Rats"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["ETB - Enabler"]
+
+["Reap What Is Sown"]
+mana_cost = ["1","W","G"]
+color_identity = "GW"
+types = ["instant"]
+tags = ["Counters - Enabler"]
+
+["Reassembling Skeleton"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Enabler","Graveyard - Payoff"]
+
+["Renegade Krasis"]
+mana_cost = ["1","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Counters - Payoff","Signpost","Keyword"]
+
+["Rhox Faithmender"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Signpost","Higher Toughness"]
+
+["Riddleform"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Spells - Payoff"]
+
+["Rise from the Tides"]
+mana_cost = ["5","U"]
+color_identity = "U"
+types = ["sorcery"]
+tags = ["Graveyard - Payoff","Spells - Payoff","Signpost","Big","Spells - Enabler"]
+
+["Rishkar, Peema Renegade"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","ETB - Enabler"]
+
+["River Hoopoe"]
+mana_cost = ["G","U"]
+color_identity = "GU"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Flash - Threat","Card Draw","Higher Toughness","Ninjutsu - Enabler"]
+
+["Rootbound Crag"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Rowdy Crew"]
+mana_cost = ["2","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Graveyard - Enabler","ETB - Enabler","Card Draw","Madness/Hellbent - Enabler"]
+
+["Rugged Highlands"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Ruin Raider"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Keyword","Card Draw"]
+
+["Runehorn Hellkite"]
+mana_cost = ["5","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Big","Madness/Hellbent - Payoff"]
+
+["Sai, Master Thopterist"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Artifacts - Payoff","Signpost","Higher Toughness"]
+
+["Sanctum Seeker"]
+mana_cost = ["2","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Signpost","Higher Toughness","Vampires - Enabler","Vampires - Payoff"]
+
+["Saproling Migration"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["sorcery"]
+tags = ["Tokens - Enabler"]
+
+["Satyr Wayfinder"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Enabler","ETB - Enabler"]
+
+["Scoured Barrens"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Scourge Wolf"]
+mana_cost = ["R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Keyword","Madness/Hellbent - Payoff"]
+
+["Scourge of Nel Toth"]
+mana_cost = ["5","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Reanimator - Payoff","Signpost","Big"]
+
+["Scrounging Bandar"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler"]
+
+["Scute Mob"]
+mana_cost = ["G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Flash - Threat","Big"]
+
+["Seal Away"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Removal"]
+
+["Second Harvest"]
+mana_cost = ["2","G","G"]
+color_identity = "G"
+types = ["instant"]
+tags = ["Tokens - Payoff","Signpost"]
+
+["Selesnya Evangel"]
+mana_cost = ["G","W"]
+color_identity = "GW"
+types = ["creature"]
+tags = ["Tokens - Enabler","Higher Toughness"]
+
+["Selesnya Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Shivan Reef"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Sickening Dreams"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = ["Madness/Hellbent - Enabler"]
+
+["Sifter Wurm"]
+mana_cost = ["5","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Big","ETB - Enabler"]
+
+["Signal Pest"]
+mana_cost = ["1"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Ninjutsu - Enabler","Artifacts - Enabler","Tokens - Payoff"]
+
+["Simic Signet"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Artifacts - Enabler"]
+
+["Sin Prodder"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Graveyard - Enabler"]
+
+["Sinister Concoction"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["enchantment"]
+tags = ["Removal","Madness/Hellbent - Enabler"]
+
+["Siren Stormtamer"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Wizards - Enabler","Ninjutsu - Enabler"]
+
+["Skarrg Guildmage"]
+mana_cost = ["R","G"]
+color_identity = "GR"
+types = ["creature"]
+tags = ["Land Graveyard - Enabler"]
+
+["Skilled Animator"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Artifacts - Payoff","Higher Toughness","Big","ETB - Enabler"]
+
+["Skinshifter"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Big","Flash - Threat","Ninjutsu - Enabler"]
+
+["Skullmulcher"]
+mana_cost = ["4","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Payoff","Counters - Enabler","Keyword","ETB - Enabler","Sacrifice - Payoff","Card Draw"]
+
+["Skymarcher Aspirant"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Keyword","Vampires - Enabler"]
+
+["Skyscanner"]
+mana_cost = ["3"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Ninjutsu - Enabler","ETB - Enabler","Artifacts - Enabler"]
+
+["Smother"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Removal"]
+
+["Soulfire Grand Master"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Lifegain - Enabler","Spells - Payoff"]
+
+["Spawnbroker"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["ETB - Enabler","Wizards - Enabler"]
+
+["Spectral Shepherd"]
+mana_cost = ["2","W"]
+color_identity = "UW"
+types = ["creature"]
+tags = ["Spirits - Enabler","Spirits - Payoff","Ninjutsu - Enabler"]
+
+["Spore Swarm"]
+mana_cost = ["3","G"]
+color_identity = "G"
+types = ["instant"]
+tags = ["Tokens - Enabler","Flash - Threat"]
+
+["Steel Overseer"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Signpost","Artifacts - Payoff","Counters - Enabler","Artifacts - Enabler"]
+
+["Steward of Solidarity"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Tokens - Enabler","Keyword"]
+
+["Stitch Together"]
+mana_cost = ["B","B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = ["Reanimator - Enabler","Keyword"]
+
+["Stitcher's Supplier"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Graveyard - Enabler"]
+
+["Stream of Unconsciousness"]
+mana_cost = ["U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Trick","Wizards - Payoff","Spells - Enabler"]
+
+["Stromkirk Condemned"]
+mana_cost = ["B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Vampires - Enabler","Vampires - Payoff","Madness/Hellbent - Enabler"]
+
+["Sulfur Falls"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Sulfurous Springs"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Sunpetal Grove"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Supernatural Stamina"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Trick","ETB - Payoff"]
+
+["Supreme Phantom"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Signpost","Spirits - Enabler","Spirits - Payoff","Higher Toughness","Ninjutsu - Enabler"]
+
+["Supreme Will"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Flash - Counterspell","Spells - Enabler"]
+
+["Swift Justice"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["instant"]
+tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler"]
+
+["Swiftwater Cliffs"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Tallowisp"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Spirits - Payoff","Keyword","Spirits - Enabler","Higher Toughness"]
+
+["Temple of Abandon"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Deceit"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Enlightenment"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Epiphany"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Malady"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Malice"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Mystery"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Plenty"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Silence"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temple of Triumph"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Temur Battle Rage"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Trick","Heroic - Enabler","Keyword","Spells - Enabler"]
+
+["Territorial Allosaurus"]
+mana_cost = ["2","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Big","Keyword"]
+
+["Teysa, Orzhov Scion"]
+mana_cost = ["1","W","B"]
+color_identity = "BW"
+types = ["creature"]
+tags = ["Signpost","Sacrifice - Payoff","Tokens - Payoff","Higher Toughness"]
+
+["The Flame of Keld"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["enchantment"]
+tags = ["Keyword","Madness/Hellbent - Enabler","Madness/Hellbent - Payoff"]
+
+["The Gitrog Monster"]
+mana_cost = ["3","B","G"]
+color_identity = "BG"
+types = ["creature"]
+tags = ["Signpost","Graveyard - Payoff","Big","Land Graveyard - Enabler","Land Graveyard - Payoff"]
+
+["Thing in the Ice"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword"]
+
+["Thirst for Knowledge"]
+mana_cost = ["2","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Artifacts - Payoff","Card Draw","Spells - Enabler","Madness/Hellbent - Enabler"]
+
+["Thopter Squadron"]
+mana_cost = ["5"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Tokens - Enabler","Counters - Enabler","Counters - Payoff","Artifacts - Enabler"]
+
+["Thornwood Falls"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Thought Courier"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Wizards - Enabler","Madness/Hellbent - Enabler"]
+
+["Throat Slitter"]
+mana_cost = ["4","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff","Removal"]
+
+["Tilling Treefolk"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Land Graveyard - Payoff","Graveyard - Payoff","Landfall - Enabler","Higher Toughness"]
+
+["Titan's Strength"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Trick","Heroic - Enabler","Spells - Enabler"]
+
+["Titania, Protector of Argoth"]
+mana_cost = ["3","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Land Graveyard - Payoff","Signpost"]
+
+["Tower Geist"]
+mana_cost = ["3","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Spirits - Enabler","ETB - Enabler","Ninjutsu - Enabler"]
+
+["Tragic Slip"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Removal"]
+
+["Tranquil Cove"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Treasure Keeper"]
+mana_cost = ["4"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Sacrifice - Enabler","Artifacts - Enabler"]
+
+["Tuktuk the Explorer"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Big"]
+
+["Tuskguard Captain"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword"]
+
+["Twinstrike"]
+mana_cost = ["3","B","R"]
+color_identity = "BR"
+types = ["instant"]
+tags = ["Removal","Madness/Hellbent - Payoff"]
+
+["Tymaret, the Murder King"]
+mana_cost = ["B","R"]
+color_identity = "BR"
+types = ["creature"]
+tags = ["Signpost","Sacrifice - Payoff"]
+
+["Ultimate Price"]
+mana_cost = ["1","B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Removal"]
+
+["Underground River"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Urbis Protector"]
+mana_cost = ["4","W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["ETB - Enabler"]
+
+["Urge to Feed"]
+mana_cost = ["B","B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Vampires - Payoff","Removal"]
+
+["Valorous Stance"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["instant"]
+tags = ["Removal","Trick","Heroic - Enabler","Spells - Enabler"]
+
+["Vampire Nighthawk"]
+mana_cost = ["1","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Higher Toughness","Vampires - Enabler","Ninjutsu - Enabler"]
+
+["Vampiric Rites"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["enchantment"]
+tags = ["Lifegain - Enabler","Sacrifice - Payoff","Card Draw"]
+
+["Vastwood Hydra"]
+mana_cost = ["X","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Big"]
+
+["Vengeful Rebel"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Removal","Sacrifice - Payoff","Keyword","ETB - Enabler"]
+
+["Verdant Embrace"]
+mana_cost = ["3","G","G"]
+color_identity = "G"
+types = ["enchantment"]
+tags = ["Tokens - Enabler","Heroic - Enabler","Big"]
+
+["Verdeloth the Ancient"]
+mana_cost = ["4","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","Big","Keyword","Higher Toughness"]
+
+["Victimize"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = ["Sacrifice - Payoff","Graveyard - Payoff","Reanimator - Enabler","Signpost"]
+
+["Viridian Zealot"]
+mana_cost = ["G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = []
+
+["Viscera Seer"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Enabler","Vampires - Enabler","Wizards - Enabler"]
+
+["Vizier of Deferment"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["ETB - Payoff","Flash - Threat"]
+
+["Vizkopa Guildmage"]
+mana_cost = ["W","B"]
+color_identity = "BW"
+types = ["creature"]
+tags = ["Lifegain - Enabler","Lifegain - Payoff","Wizards - Enabler"]
+
+["Voyage's End"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Bounce","Spells - Enabler"]
+
+["Wall of Omens"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Higher Toughness","ETB - Enabler"]
+
+["Weatherlight"]
+mana_cost = ["4"]
+color_identity = "C"
+types = ["artifact"]
+tags = ["Signpost","Artifacts - Payoff","Keyword","Card Draw","Artifacts - Enabler"]
+
+["Whisper, Blood Liturgist"]
+mana_cost = ["3","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Reanimator - Enabler","Signpost","ETB - Payoff"]
+
+["Wind-Scarred Crag"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Wizard's Lightning"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Wizards - Payoff","Removal","Spells - Enabler"]
+
+["Wizard's Retort"]
+mana_cost = ["1","U","U"]
+color_identity = "U"
+types = ["instant"]
+tags = ["Wizards - Payoff","Flash - Counterspell","Spells - Enabler"]
+
+["Woodland Cemetery"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["World Shaper"]
+mana_cost = ["3","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Land Graveyard - Payoff","Graveyard - Enabler","Landfall - Enabler"]
+
+["Yavimaya Coast"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = []
+
+["Yavimaya Sapherd"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","ETB - Enabler"]
+
+["Young Pyromancer"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Signpost","Spells - Payoff","Tokens - Enabler"]
+
+["Yuriko, the Tiger's Shadow"]
+mana_cost = ["1","U","B"]
+color_identity = "BU"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff","Signpost"]
+
+["Zombify"]
+mana_cost = ["3","B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = ["Reanimator - Enabler"]

--- a/draft_python/tests/test_api.py
+++ b/draft_python/tests/test_api.py
@@ -19,18 +19,18 @@ def picker():
 
 
 def test_drafter_pick(draft_info, picker):
-    drafter = Drafter(picker)
+    drafter = Drafter(picker, draft_info)
     picked = drafter.pick([1, 2, 3])
 
     assert picked == PICKED_CARD
     assert drafter.cards_owned == [PICKED_CARD]
-    picker.pick.assert_called_with(pack=[1, 2, 3], cards_owned=[])
+    picker.pick.assert_called_with(pack=[1, 2, 3], cards_owned=[], draft_info=draft_info)
 
 
 def test_picker_invalid_pick(draft_info, picker):
     with pytest.raises(ValueError) as excinfo:
         picker.pick.return_value = 'Ace of Spades'
-        drafter = Drafter(picker)
+        drafter = Drafter(picker, draft_info)
         drafter.pick(pack=[1, 2, 3])
     assert 'Drafter made invalid pick Ace of Spades' in str(excinfo)
 

--- a/draft_python/tests/test_controller.py
+++ b/draft_python/tests/test_controller.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from mtg_draft_ai.controller import create_packs, read_cube_list, DraftController
-from mtg_draft_ai.api import DraftInfo, Drafter, Packs, Card
+from mtg_draft_ai.api import DraftInfo, Drafter, Packs, Card, Picker
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -43,7 +43,7 @@ def test_create_packs_invalid_config(draft_info):
 
 
 def test_controller_create(draft_info):
-    drafters = [Drafter(FirstPicker()) for _ in range(0, 4)]
+    drafters = [Drafter(FirstPicker(), draft_info) for _ in range(0, 4)]
     controller = DraftController.create(draft_info=draft_info, drafters=drafters)
     assert controller.drafters == drafters
     assert len(controller.packs.pack_contents) == 3
@@ -55,8 +55,8 @@ def test_run_draft():
     pack_contents = [[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
                     [[13, 14, 15, 16], [17, 18, 19, 20], [21, 22, 23, 24]],
                     [[25, 26, 27, 28], [29, 30, 31, 32], [33, 34, 35, 36]]]
-    drafters = [Drafter(FirstPicker()) for _ in range(0, 3)]
     draft_info = DraftInfo(card_list=list(range(1, 37)), cards_per_pack=4, num_phases=3, num_drafters=3)
+    drafters = [Drafter(FirstPicker(), draft_info) for _ in range(0, 3)]
 
     controller = DraftController(packs=Packs(pack_contents), drafters=drafters, draft_info=draft_info)
     controller.run_draft()
@@ -68,8 +68,8 @@ def test_run_draft():
     assert all_picks == set(range(1, 37))
 
 
-class FirstPicker:
-    def pick(self, pack, cards_owned):
+class FirstPicker(Picker):
+    def pick(self, pack, cards_owned, draft_info):
         return pack[0]
 
 

--- a/draft_python/tests/test_controller.py
+++ b/draft_python/tests/test_controller.py
@@ -58,7 +58,7 @@ def test_run_draft():
     draft_info = DraftInfo(card_list=list(range(1, 37)), cards_per_pack=4, num_phases=3, num_drafters=3)
     drafters = [Drafter(FirstPicker(), draft_info) for _ in range(0, 3)]
 
-    controller = DraftController(packs=Packs(pack_contents), drafters=drafters, draft_info=draft_info)
+    controller = DraftController(packs=Packs(pack_contents), drafters=drafters, draft_info=draft_info, debug=False)
     controller.run_draft()
 
     assert drafters[0].cards_owned == [1, 6, 11, 4,

--- a/draft_python/tests/test_draftlog.py
+++ b/draft_python/tests/test_draftlog.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+from io import StringIO
+
+from mtg_draft_ai import draftlog
+from mtg_draft_ai.controller import DraftController, read_cube_toml
+from mtg_draft_ai.api import DraftInfo, Drafter
+from mtg_draft_ai.brains import RandomPicker
+
+
+TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+
+@pytest.fixture
+def draft_info():
+    cube_list = read_cube_toml(os.path.join(TEST_DATA_DIR, 'cube_81183_tag_data.toml'))
+    return DraftInfo(card_list=cube_list,
+                     cards_per_pack=5, num_phases=3, num_drafters=4)
+
+
+@pytest.fixture
+def controller(draft_info):
+    drafters = [Drafter(RandomPicker(), draft_info) for _ in range(0, 4)]
+    return DraftController.create(draft_info=draft_info, drafters=drafters, debug=False)
+
+
+def test_log_full_draft(controller):
+    drafters = controller.drafters
+    controller.run_draft()
+
+    # Use in-memory buffer instead of actual file
+    log_file = StringIO(draftlog.dumps_log(drafters, controller.draft_info))
+    loaded_drafters = draftlog.load_drafters_from_log(log_file)
+
+    # loaded_drafters use card names, not full card objects, since it doesn't depend on a tagged data file.
+    # for assertions, compare card names to the loaded strings.
+    for drafter, loaded in zip(drafters, loaded_drafters):
+        assert [c.name for c in drafter.cards_owned] == loaded.cards_owned
+        for pack, loaded_pack in zip(drafter.pack_history, loaded.pack_history):
+            assert [c.name for c in pack] == loaded_pack
+
+
+def test_log_to_html(controller):
+    controller.run_draft()
+    log_file = StringIO(draftlog.dumps_log(controller.drafters, controller.draft_info))
+
+    # It's difficult to actually validate the output html, so just a minimal assertion here
+    html = draftlog.log_to_html(log_file)
+    assert 'scryfall' in html

--- a/draft_python/tests/test_greedy_synergy_picker.py
+++ b/draft_python/tests/test_greedy_synergy_picker.py
@@ -1,3 +1,4 @@
+import mock
 import os
 import pytest
 from mtg_draft_ai.brains import GreedySynergyPicker, all_common_neighbors
@@ -26,6 +27,11 @@ def graph(cards):
     return synergy.create_graph(cards)
 
 
+@pytest.fixture
+def draft_info():
+    return mock.Mock(name='draft_info')
+
+
 def test_all_common_neighbors_coverage(graph, cards):
     common = all_common_neighbors(graph, cards)
 
@@ -46,14 +52,14 @@ def test_common_neighbors_found(graph, cards, cards_by_name):
     assert set(common[c1][c2]) == {cards_by_name[n] for n in expected_neighbor_names}
 
 
-def test_greedy_synergy_picker(cards, cards_by_name):
+def test_greedy_synergy_picker(cards, cards_by_name, draft_info):
     picker = GreedySynergyPicker.factory(cards).create()
     owned_card_names = ['Abzan Battle Priest', "Ajani's Pridemate"]
     pack_card_names = ['Ayli, Eternal Pilgrim', 'Tuskguard Captain']
     owned_cards = [cards_by_name[n] for n in owned_card_names]
     pack = [cards_by_name[n] for n in pack_card_names]
 
-    ratings = picker._ratings(pack=pack, cards_owned=owned_cards)
+    ratings = picker._ratings(pack=pack, cards_owned=owned_cards, draft_info=draft_info)
 
     # Ayli in WB only, Tuskguard Captain in GW/GU/GR/GB
     assert len(ratings) == 5
@@ -62,6 +68,5 @@ def test_greedy_synergy_picker(cards, cards_by_name):
     assert top_ranked.card == cards_by_name['Ayli, Eternal Pilgrim']
     # Expected:
     # total edges: priest/pridemate/ayli all connected
-    # new edges: priest/ayli and pridemate/ayli
     # common neighbors (not already in pool): swift justice
-    assert top_ranked[1:] == ('WB', 3, 2, 1, picker.default_ratings[top_ranked.card])
+    assert top_ranked[1:] == ('WB', 3, 1, picker.default_ratings[top_ranked.card])


### PR DESCRIPTION
With this change, you can:

- record a finished draft as a TOML file
- load the draft state back into memory from a TOML draft log file
- create an HTML view of a draft

Changes are mostly in draftlog.py and display.py; the rest of the changes just support those.

Try it out by checking out this branch and running
```python draft.py```