### PR TITLE
Update bot to factor in card power level

### DIFF
--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -38,7 +38,7 @@ tags = ["Heroic - Payoff","Keyword","Tier 4"]
 mana_cost = ["W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Enabler","Keyword","Spirits - Enabler","ETB - Enabler","Tier 1"]
+tags = ["Counters - Enabler","Keyword","Spirits - Enabler","ETB - Enabler","Tier 2"]
 
 ["Anax and Cymede"]
 mana_cost = ["1","W","R"]
@@ -170,7 +170,7 @@ tags = ["Signpost","Big","Keyword","Vampires - Enabler","Madness/Hellbent - Payo
 mana_cost = ["4","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Payoff","Vampires - Enabler","Wizards - Payoff","Wizards - Enabler","Tier 1","Spice"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Payoff","Vampires - Enabler","Wizards - Payoff","Wizards - Enabler","Spice","Tier 2"]
 
 ["Bloodmist Infiltrator"]
 mana_cost = ["2","B"]
@@ -188,7 +188,7 @@ tags = ["Madness/Hellbent - Enabler","Tier 3"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Keyword","Tier 2"]
+tags = ["Sacrifice - Enabler","Keyword","Tier 2","Madness/Hellbent - Payoff"]
 
 ["Bloodspore Thrinax"]
 mana_cost = ["2","G","G"]
@@ -428,7 +428,7 @@ tags = ["Big","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifac
 mana_cost = ["U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Card Draw","Tier 1"]
+tags = ["Heroic - Enabler","Card Draw","Tier 1","Ninjutsu - Payoff"]
 
 ["Dark-Dweller Oracle"]
 mana_cost = ["1","R"]
@@ -974,7 +974,7 @@ tags = []
 mana_cost = ["4","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Signpost","Higher Toughness","Big","Tier 2"]
+tags = ["Graveyard - Payoff","Signpost","Higher Toughness","Big","Tier 1"]
 
 ["Key to the City"]
 mana_cost = ["2"]
@@ -1514,7 +1514,7 @@ tags = ["Counters - Enabler","Tier 3"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Graveyard - Payoff","Tier 2"]
+tags = ["Sacrifice - Enabler","Graveyard - Payoff","Tier 2","Madness/Hellbent - Payoff"]
 
 ["Reckless Racer"]
 mana_cost = ["2","R"]
@@ -1556,7 +1556,7 @@ tags = ["Counters - Enabler","ETB - Enabler","Tier 1","Ramp - Enabler"]
 mana_cost = ["G","U"]
 color_identity = "GU"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Flash - Threat","Card Draw","Higher Toughness","Ninjutsu - Enabler","Tier 4"]
+tags = ["Lifegain - Enabler","Flash - Threat","Card Draw","Higher Toughness","Ninjutsu - Enabler","Tier 3","Ramp - Payoff"]
 
 ["Rootbound Crag"]
 mana_cost = []
@@ -1622,7 +1622,7 @@ tags = ["Keyword","Madness/Hellbent - Payoff","Tier 2"]
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Signpost","Big","Tier 2","Spice"]
+tags = ["Reanimator - Payoff","Signpost","Big","Spice","Madness/Hellbent - Payoff","Graveyard - Payoff","Tier 1"]
 
 ["Scrounging Bandar"]
 mana_cost = ["1","G"]
@@ -1664,7 +1664,7 @@ tags = []
 mana_cost = ["1","B","G","U"]
 color_identity = "BGU"
 types = ["creature"]
-tags = ["Signpost","Graveyard - Enabler","Graveyard - Payoff","Tier 1"]
+tags = ["Signpost","Graveyard - Enabler","Graveyard - Payoff","Tier 2"]
 
 ["Sifter Wurm"]
 mana_cost = ["5","G","G"]
@@ -2108,7 +2108,7 @@ tags = ["Removal","Sacrifice - Payoff","Keyword","ETB - Enabler","Removal - Size
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["sorcery"]
-tags = ["Graveyard - Payoff","Reanimator - Enabler","Signpost","Tier 2","Spice"]
+tags = ["Graveyard - Payoff","Reanimator - Enabler","Signpost","Spice","Tier 1"]
 
 ["Viridian Zealot"]
 mana_cost = ["G","G"]

--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -2,7 +2,7 @@
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler","Tier 2","Ramp - Payoff"]
+tags = ["Reanimator - Payoff","Big","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Abzan Battle Priest"]
 mana_cost = ["3","W"]

--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -20,7 +20,7 @@ tags = []
 mana_cost = ["1","U","R"]
 color_identity = "UR"
 types = ["creature"]
-tags = ["Spells - Payoff","Wizards - Payoff","Wizards - Enabler","Tier 1"]
+tags = ["Spells - Payoff","Wizards - Payoff","Wizards - Enabler","Tier 2"]
 
 ["Ajani's Pridemate"]
 mana_cost = ["1","W"]
@@ -122,7 +122,7 @@ tags = ["Card Draw","Madness/Hellbent - Enabler","Tier 1","Spice"]
 mana_cost = ["W"]
 color_identity = "W"
 types = ["instant"]
-tags = ["Tier 2","Heroic - Enabler"]
+tags = ["Heroic - Enabler","Spells - Enabler","Tier 3"]
 
 ["Banisher Priest"]
 mana_cost = ["1","W","W"]
@@ -230,7 +230,7 @@ tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreat
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Removal","Keyword","Heroic - Enabler","Tier 2"]
+tags = ["Removal","Keyword","Heroic - Enabler","Tier 3"]
 
 ["Bounding Krasis"]
 mana_cost = ["1","U","G"]
@@ -494,7 +494,7 @@ tags = ["Trick","Heroic - Enabler","Spells - Enabler","Flash - Interaction","Tie
 mana_cost = ["3","W","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Signpost","Spice","Tier 2","Tokens - Payoff"]
+tags = ["Signpost","Spice","Tokens - Payoff","Tier 1"]
 
 ["Dragon Mantle"]
 mana_cost = ["R"]
@@ -638,7 +638,7 @@ tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler","Art
 mana_cost = ["3","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["ETB - Enabler","Tokens - Enabler","Tier 3","cuttable"]
+tags = ["ETB - Enabler","Tokens - Enabler","cuttable","Tier 4"]
 
 ["Gather the Townsfolk"]
 mana_cost = ["1","W"]
@@ -734,7 +734,7 @@ tags = ["Higher Toughness","ETB - Enabler","Tier 1"]
 mana_cost = ["1","G","W"]
 color_identity = "GW"
 types = ["creature"]
-tags = ["Tier 2","Counters - Enabler","Tokens - Payoff"]
+tags = ["Counters - Enabler","Tokens - Payoff","Tier 3"]
 
 ["Grateful Apparition"]
 mana_cost = ["1","W"]
@@ -932,7 +932,7 @@ tags = ["Higher Toughness","Wizards - Enabler","Card Draw","Tier 2","Spice"]
 mana_cost = ["1","B","R"]
 color_identity = "BR"
 types = ["creature"]
-tags = ["Sacrifice - Payoff","Signpost","Tier 1","Spice"]
+tags = ["Sacrifice - Payoff","Signpost","Spice","Tier 2"]
 
 ["Kalastria Highborn"]
 mana_cost = ["B","B"]
@@ -1046,7 +1046,7 @@ tags = ["Big","Flash - Threat","Tier 2"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Tier 3","Madness/Hellbent - Payoff","Artifacts (Cheap) - Enabler","Artifacts (Creature) - Enabler","Artifacts - Enabler"]
+tags = ["Madness/Hellbent - Payoff","Artifacts (Cheap) - Enabler","Artifacts (Creature) - Enabler","Artifacts - Enabler","Tier 4"]
 
 ["Magma Burst"]
 mana_cost = ["3","R"]
@@ -1184,7 +1184,7 @@ tags = ["Card Draw","Madness/Hellbent - Payoff","Artifacts - Enabler","Artifacts
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Tier 2","Tokens - Enabler","Sacrifice - Enabler","Keyword"]
+tags = ["Tokens - Enabler","Sacrifice - Enabler","Keyword","Tier 3"]
 
 ["Mirror Mockery"]
 mana_cost = ["1","U"]
@@ -1322,13 +1322,13 @@ tags = ["Landfall - Enabler","Tier 1","Spice","Ramp - Enabler"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Lifegain - Enabler","Counters - Enabler","Tier 3"]
+tags = ["Heroic - Enabler","Lifegain - Enabler","Counters - Enabler","Tier 4"]
 
 ["Ordeal of Thassa"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw","Tier 2"]
+tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw","Ninjutsu - Payoff","Tier 3"]
 
 ["Orzhov Signet"]
 mana_cost = ["2"]
@@ -1376,7 +1376,7 @@ tags = ["Signpost","ETB - Payoff","Artifacts - Enabler","Artifacts (Noncreature)
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Lifegain - Enabler","Lifegain - Payoff","Tokens - Payoff","Tier 2"]
+tags = ["Lifegain - Enabler","Lifegain - Payoff","Tokens - Payoff","Tier 3"]
 
 ["Path of Discovery"]
 mana_cost = ["3","G"]
@@ -1406,7 +1406,7 @@ tags = ["Signpost","Heroic - Payoff","Counters - Enabler","Keyword","Tier 2","Sp
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Enabler","Spirits - Enabler","Tier 2"]
+tags = ["Counters - Enabler","Spirits - Enabler","Tier 3"]
 
 ["Pianna, Nomad Captain"]
 mana_cost = ["1","W","W"]
@@ -1574,7 +1574,7 @@ tags = ["Graveyard - Enabler","ETB - Enabler","Card Draw","Madness/Hellbent - En
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Keyword","Card Draw","Tier 2"]
+tags = ["Keyword","Card Draw","Tier 2","Ninjutsu - Payoff"]
 
 ["Runaway Steam-Kin"]
 mana_cost = ["1","R"]
@@ -1850,7 +1850,7 @@ tags = ["Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent
 mana_cost = ["W"]
 color_identity = "W"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler","Tier 2"]
+tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler","Tier 3"]
 
 ["Tallowisp"]
 mana_cost = ["1","W"]

--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -2,19 +2,13 @@
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler","Tier 2"]
+tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler","Tier 2","Ramp - Payoff"]
 
 ["Abzan Battle Priest"]
 mana_cost = ["3","W"]
 color_identity = "W"
 types = ["creature"]
 tags = ["Counters - Payoff","Keyword","Lifegain - Enabler","Counters - Enabler","Tier 3"]
-
-["Accorder Paladin"]
-mana_cost = ["1","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Tokens - Payoff","Keyword","Tier 2"]
 
 ["Adarkar Wastes"]
 mana_cost = []
@@ -64,12 +58,6 @@ color_identity = "W"
 types = ["enchantment"]
 tags = ["Heroic - Enabler","Tier 3"]
 
-["Anowon, the Ruin Sage"]
-mana_cost = ["3","B","B"]
-color_identity = "B"
-types = ["creature"]
-tags = ["Vampires - Enabler","Vampires - Payoff","Sacrifice - Payoff","Signpost","Tier 3","cuttable"]
-
 ["Armorcraft Judge"]
 mana_cost = ["3","G"]
 color_identity = "G"
@@ -98,7 +86,7 @@ tags = ["ETB - Enabler","Ninjutsu - Enabler","Tier 3"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["sorcery"]
-tags = ["Signpost","Madness/Hellbent - Payoff","Spells - Enabler","Removal - Size","Removal","Tier 3"]
+tags = ["Signpost","Madness/Hellbent - Payoff","Spells - Enabler","Removal - Size","Removal","Tier 3","Keyword"]
 
 ["Avaricious Dragon"]
 mana_cost = ["2","R","R"]
@@ -118,17 +106,11 @@ color_identity = "U"
 types = ["creature"]
 tags = ["Signpost","Wizards - Payoff","Wizards - Enabler","Card Draw","Tier 1"]
 
-["Azorius Herald"]
-mana_cost = ["2","W"]
-color_identity = "UW"
-types = ["creature"]
-tags = ["Spirits - Enabler","Lifegain - Enabler","ETB - Enabler","Tier 2"]
-
 ["Azorius Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Azra Oddsmaker"]
 mana_cost = ["1","B","R"]
@@ -148,12 +130,6 @@ color_identity = "W"
 types = ["creature"]
 tags = ["Removal","ETB - Enabler","Tier 2"]
 
-["Banishing Light"]
-mana_cost = ["2","W"]
-color_identity = "W"
-types = ["enchantment"]
-tags = ["Removal","Tier 2","Noncreature Permanent Interaction"]
-
 ["Battlefield Forge"]
 mana_cost = []
 color_identity = "C"
@@ -170,7 +146,7 @@ tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword","Card Dr
 mana_cost = ["G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Ninjutsu - Enabler","Tier 1"]
+tags = ["Ninjutsu - Enabler","Tier 1","Ramp - Enabler"]
 
 ["Bishop of Rebirth"]
 mana_cost = ["3","W","W"]
@@ -248,7 +224,7 @@ tags = ["Removal","Sacrifice - Payoff","Tier 4"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Bound by Moonsilver"]
 mana_cost = ["2","W"]
@@ -290,7 +266,7 @@ tags = []
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Land Graveyard - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Creature) - Payoff"]
+tags = ["Land Graveyard - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Creature) - Payoff","Tier 3"]
 
 ["Burning Prophet"]
 mana_cost = ["1","R"]
@@ -303,6 +279,12 @@ mana_cost = ["2","W","B"]
 color_identity = "BW"
 types = ["sorcery"]
 tags = ["Tokens - Enabler","Lifegain - Enabler","Vampires - Enabler","Tier 3"]
+
+["Camaraderie"]
+mana_cost = ["4","G","W"]
+color_identity = "GW"
+types = ["sorcery"]
+tags = ["Spice","Tier 2","Signpost","Tokens - Payoff"]
 
 ["Cathartic Reunion"]
 mana_cost = ["1","R"]
@@ -382,23 +364,23 @@ color_identity = "G"
 types = ["sorcery"]
 tags = ["Graveyard - Enabler","Tier 2"]
 
+["Conclave Tribunal"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Tier 2","Removal","Tokens - Payoff"]
+
 ["Countryside Crusher"]
 mana_cost = ["1","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Land Graveyard - Payoff","Land Graveyard - Enabler","Big","Tier 2"]
+tags = ["Tier 3","Land Graveyard - Enabler","Land Graveyard - Payoff"]
 
 ["Crawling Sensation"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["enchantment"]
 tags = ["Graveyard - Enabler","Land Graveyard - Payoff","Tier 4"]
-
-["Crested Herdcaller"]
-mana_cost = ["3","G","G"]
-color_identity = "G"
-types = ["creature"]
-tags = ["Tokens - Enabler","ETB - Enabler","Tier 2"]
 
 ["Crested Sunmare"]
 mana_cost = ["3","W","W"]
@@ -470,13 +452,13 @@ tags = ["ETB - Enabler","Removal","Tier 3"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tier 2"]
+tags = ["Tier 2","Ramp - Enabler"]
 
 ["Dimir Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Dinrova Horror"]
 mana_cost = ["4","U","B"]
@@ -532,6 +514,12 @@ color_identity = "U"
 types = ["enchantment"]
 tags = ["Signpost","Madness/Hellbent - Payoff","Tier 3","Spice"]
 
+["Drogskol Captain"]
+mana_cost = ["1","W","U"]
+color_identity = "UW"
+types = ["creature"]
+tags = ["Signpost","Tier 2","Spirits - Enabler","Spirits - Payoff"]
+
 ["Drowned Catacomb"]
 mana_cost = []
 color_identity = "C"
@@ -554,7 +542,7 @@ tags = ["Sacrifice - Enabler","ETB - Enabler","Tier 3"]
 mana_cost = ["X","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler","Flash - Threat","Tier 3"]
+tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler","Flash - Threat","Tier 3","Ramp - Payoff"]
 
 ["Essence Flux"]
 mana_cost = ["U"]
@@ -578,7 +566,7 @@ tags = ["Landfall - Enabler","Graveyard - Enabler","Madness/Hellbent - Enabler",
 mana_cost = ["X","X","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Removal","Heroic - Enabler","Keyword","Spells - Enabler","Removal - Size","Tier 1"]
+tags = ["Removal","Heroic - Enabler","Keyword","Spells - Enabler","Removal - Size","Tier 1","Ramp - Payoff"]
 
 ["Familiar's Ruse"]
 mana_cost = ["U","U"]
@@ -616,6 +604,12 @@ color_identity = "BR"
 types = ["creature"]
 tags = ["Sacrifice - Payoff","Tier 3"]
 
+["Fists of Flame"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Heroic - Enabler","Spells - Enabler","Tier 2","Spice","Trick"]
+
 ["Fists of Ironwood"]
 mana_cost = ["1","G"]
 color_identity = "G"
@@ -638,7 +632,7 @@ tags = []
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Tier 3"]
 
 ["Gallant Cavalry"]
 mana_cost = ["3","W"]
@@ -662,7 +656,7 @@ tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword","E
 mana_cost = ["X","G","G","G"]
 color_identity = "G"
 types = ["sorcery"]
-tags = ["Big","Tier 3"]
+tags = ["Big","Tier 3","Ramp - Payoff"]
 
 ["Ghitu Lavarunner"]
 mana_cost = ["R"]
@@ -710,7 +704,7 @@ tags = ["Tokens - Enabler","Sacrifice - Enabler","Tier 4"]
 mana_cost = ["3","R"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Land Graveyard - Enabler","Tier 3"]
+tags = ["Land Graveyard - Enabler","Tier 3","Ramp - Enabler"]
 
 ["Goblin Instigator"]
 mana_cost = ["1","R"]
@@ -728,7 +722,7 @@ tags = ["Signpost","Artifacts - Payoff","Tier 2","Spice"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Gonti, Lord of Luxury"]
 mana_cost = ["2","B","B"]
@@ -736,11 +730,17 @@ color_identity = "B"
 types = ["creature"]
 tags = ["Higher Toughness","ETB - Enabler","Tier 1"]
 
+["Good-Fortune Unicorn"]
+mana_cost = ["1","G","W"]
+color_identity = "GW"
+types = ["creature"]
+tags = ["Tier 2","Counters - Enabler","Tokens - Payoff"]
+
 ["Grateful Apparition"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Payoff","Spirits - Enabler","Ninjutsu - Enabler","Tier 3"]
+tags = ["Counters - Payoff","Spirits - Enabler","Ninjutsu - Enabler","Tier 3","Keyword"]
 
 ["Graveyard Marshal"]
 mana_cost = ["B","B"]
@@ -758,7 +758,7 @@ tags = ["Lifegain - Enabler","Landfall - Payoff","Tier 3"]
 mana_cost = ["4","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Big","ETB - Enabler","Tier 1"]
+tags = ["Graveyard - Payoff","Big","ETB - Enabler","Tier 1","Ramp - Payoff"]
 
 ["Gruesome Menagerie"]
 mana_cost = ["3","B","B"]
@@ -770,7 +770,7 @@ tags = ["Graveyard - Payoff","Tier 2","Spice"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Gyre Sage"]
 mana_cost = ["1","G"]
@@ -812,7 +812,7 @@ tags = ["Tokens - Enabler","Graveyard - Payoff","Spirits - Enabler","ETB - Enabl
 mana_cost = ["4"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Tier 2"]
+tags = ["Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Tier 2","Ramp - Enabler"]
 
 ["Heir of Falkenrath"]
 mana_cost = ["1","B"]
@@ -854,7 +854,7 @@ tags = ["Counters - Enabler","Counters - Payoff","Tokens - Enabler","Tier 2","Sp
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Land Graveyard - Payoff"]
+tags = ["Land Graveyard - Payoff","Tier 3"]
 
 ["Illusionist's Stratagem"]
 mana_cost = ["3","U"]
@@ -872,19 +872,13 @@ tags = ["Removal","Spells - Enabler","Removal - Size","Tier 2"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tier 1","Counters - Payoff","Flash - Threat"]
+tags = ["Tier 1","Counters - Payoff","Flash - Threat","Keyword","Ramp - Enabler"]
 
 ["Indulgent Aristocrat"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
 tags = ["Sacrifice - Payoff","Lifegain - Enabler","Counters - Enabler","Vampires - Enabler","Vampires - Payoff","Tier 3"]
-
-["Inferno Fist"]
-mana_cost = ["1","R"]
-color_identity = "R"
-types = ["enchantment"]
-tags = ["Tier 3","Heroic - Enabler","Removal","Removal - Size"]
 
 ["Inspiring Cleric"]
 mana_cost = ["2","W"]
@@ -914,7 +908,7 @@ tags = ["Spells - Payoff","Graveyard - Payoff","Signpost","Higher Toughness","Wi
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Jace's Archivist"]
 mana_cost = ["1","U","U"]
@@ -939,12 +933,6 @@ mana_cost = ["1","B","R"]
 color_identity = "BR"
 types = ["creature"]
 tags = ["Sacrifice - Payoff","Signpost","Tier 1","Spice"]
-
-["Juniper Order Ranger"]
-mana_cost = ["3","G","W"]
-color_identity = "GW"
-types = ["creature"]
-tags = ["Counters - Enabler","Tokens - Payoff","ETB - Enabler","Higher Toughness","Tier 3"]
 
 ["Kalastria Highborn"]
 mana_cost = ["B","B"]
@@ -1018,12 +1006,6 @@ color_identity = "B"
 types = ["creature"]
 tags = ["Ninjutsu - Enabler","Tier 2","Noncreature Permanent Interaction"]
 
-["Knotvine Paladin"]
-mana_cost = ["G","W"]
-color_identity = "GW"
-types = ["creature"]
-tags = ["Tokens - Payoff","Tier 2"]
-
 ["Lantern Kami"]
 mana_cost = ["W"]
 color_identity = "W"
@@ -1076,7 +1058,7 @@ tags = ["Keyword","Land Graveyard - Enabler","Removal","Spells - Enabler","Remov
 mana_cost = ["5","R","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Big","Reanimator - Payoff","Tier 3"]
+tags = ["Big","Reanimator - Payoff","Tier 3","Ramp - Payoff"]
 
 ["Magmatic Insight"]
 mana_cost = ["R"]
@@ -1138,11 +1120,17 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
+["Memorial to Glory"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = ["Land Graveyard - Enabler","Tokens - Enabler","Tier 3"]
+
 ["Memorial to Unity"]
 mana_cost = []
 color_identity = "G"
 types = ["land"]
-tags = ["Land Graveyard - Enabler"]
+tags = ["Land Graveyard - Enabler","Tier 3"]
 
 ["Metallic Mimic"]
 mana_cost = ["2"]
@@ -1196,7 +1184,7 @@ tags = ["Card Draw","Madness/Hellbent - Payoff","Artifacts - Enabler","Artifacts
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Tier 2","Tokens - Enabler","Sacrifice - Enabler"]
+tags = ["Tier 2","Tokens - Enabler","Sacrifice - Enabler","Keyword"]
 
 ["Mirror Mockery"]
 mana_cost = ["1","U"]
@@ -1215,6 +1203,12 @@ mana_cost = ["R"]
 color_identity = "R"
 types = ["enchantment"]
 tags = ["Land Graveyard - Enabler","Removal","Removal - Size","Tier 2"]
+
+["Mother Bear"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Tokens - Enabler","Tier 3"]
 
 ["Murderous Cut"]
 mana_cost = ["4","B"]
@@ -1262,7 +1256,7 @@ tags = ["Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent
 mana_cost = ["3","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Higher Toughness","Big","Keyword","Tier 2"]
+tags = ["Higher Toughness","Big","Keyword","Tier 2","Ramp - Enabler"]
 
 ["Niblis of the Urn"]
 mana_cost = ["1","W"]
@@ -1304,13 +1298,7 @@ tags = ["Ninjutsu - Payoff","Tier 3"]
 mana_cost = ["3","R","R","G","G"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Landfall - Payoff","Keyword","Tier 2"]
-
-["One Dozen Eyes"]
-mana_cost = ["5","G"]
-color_identity = "G"
-types = ["sorcery"]
-tags = ["Tokens - Enabler","Tier 2"]
+tags = ["Reanimator - Payoff","Big","Landfall - Payoff","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Oppressive Rays"]
 mana_cost = ["W"]
@@ -1328,7 +1316,7 @@ tags = ["Spells - Enabler","Tier 2"]
 mana_cost = ["3","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Landfall - Enabler","Tier 1","Spice"]
+tags = ["Landfall - Enabler","Tier 1","Spice","Ramp - Enabler"]
 
 ["Ordeal of Heliod"]
 mana_cost = ["1","W"]
@@ -1346,7 +1334,7 @@ tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw",
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Outnumber"]
 mana_cost = ["R"]
@@ -1376,7 +1364,7 @@ tags = ["Land Graveyard - Enabler","Spirits - Enabler","Flash - Threat","Tier 2"
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2"]
+tags = ["Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2","Ramp - Enabler"]
 
 ["Panharmonicon"]
 mana_cost = ["4"]
@@ -1438,12 +1426,6 @@ color_identity = "C"
 types = ["artifact"]
 tags = ["Keyword","Artifacts - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
 
-["Pongify"]
-mana_cost = ["U"]
-color_identity = "U"
-types = ["instant"]
-tags = ["Removal","Trick","Flash - Threat","Spells - Enabler","Tier 4","cuttable"]
-
 ["Pore Over the Pages"]
 mana_cost = ["3","U","U"]
 color_identity = "U"
@@ -1460,7 +1442,7 @@ tags = ["ETB - Enabler","Tier 2"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["enchantment"]
-tags = ["Tokens - Enabler","Heroic - Enabler","Tier 4"]
+tags = ["Tokens - Enabler","Heroic - Enabler","Tier 4","cuttable"]
 
 ["Prey Upon"]
 mana_cost = ["G"]
@@ -1478,7 +1460,7 @@ tags = ["Signpost","Higher Toughness","Wizards - Enabler","Flash - Threat","Tier
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 4"]
 
 ["Pyrite Spellbomb"]
 mana_cost = ["1"]
@@ -1502,7 +1484,7 @@ tags = ["ETB - Payoff","Ninjutsu - Enabler","Flash - Threat","Tier 3"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Ramunap Excavator"]
 mana_cost = ["2","G"]
@@ -1568,7 +1550,7 @@ tags = ["Graveyard - Payoff","Spells - Payoff","Signpost","Big","Spells - Enable
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","ETB - Enabler","Tier 1"]
+tags = ["Counters - Enabler","ETB - Enabler","Tier 1","Ramp - Enabler"]
 
 ["River Hoopoe"]
 mana_cost = ["G","U"]
@@ -1593,6 +1575,12 @@ mana_cost = ["2","B"]
 color_identity = "B"
 types = ["creature"]
 tags = ["Keyword","Card Draw","Tier 2"]
+
+["Runaway Steam-Kin"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Tier 2","Spice"]
 
 ["Sai, Master Thopterist"]
 mana_cost = ["2","U"]
@@ -1654,12 +1642,6 @@ color_identity = "W"
 types = ["enchantment"]
 tags = ["Removal","Tier 3"]
 
-["Second Harvest"]
-mana_cost = ["2","G","G"]
-color_identity = "G"
-types = ["instant"]
-tags = ["Tokens - Payoff","Signpost","Tier 4"]
-
 ["Selesnya Evangel"]
 mana_cost = ["G","W"]
 color_identity = "GW"
@@ -1670,7 +1652,7 @@ tags = ["Tokens - Enabler","Higher Toughness","Tier 2"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Shivan Reef"]
 mana_cost = []
@@ -1688,19 +1670,13 @@ tags = ["Signpost","Graveyard - Enabler","Graveyard - Payoff","Tier 1"]
 mana_cost = ["5","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Big","ETB - Enabler","Tier 3"]
-
-["Signal Pest"]
-mana_cost = ["1"]
-color_identity = "C"
-types = ["artifact","creature"]
-tags = ["Ninjutsu - Enabler","Artifacts - Enabler","Tokens - Payoff","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 4"]
+tags = ["Big","ETB - Enabler","Tier 3","Ramp - Payoff"]
 
 ["Simic Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Sin Prodder"]
 mana_cost = ["2","R"]
@@ -1744,17 +1720,17 @@ color_identity = "G"
 types = ["creature"]
 tags = ["Tokens - Payoff","Counters - Enabler","Keyword","ETB - Enabler","Sacrifice - Payoff","Card Draw","Tier 1","Spice"]
 
-["Skymarcher Aspirant"]
-mana_cost = ["W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Keyword","Vampires - Enabler","Tier 3"]
-
 ["Skyscanner"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact","creature"]
 tags = ["Ninjutsu - Enabler","ETB - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
+
+["Smoke Shroud"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Ninjutsu - Enabler","Tier 3"]
 
 ["Soul's Fire"]
 mana_cost = ["2","R"]
@@ -1768,11 +1744,11 @@ color_identity = "W"
 types = ["creature"]
 tags = ["Signpost","Lifegain - Enabler","Spells - Payoff","Tier 1","Spice"]
 
-["Spectral Shepherd"]
-mana_cost = ["2","W"]
+["Soulherder"]
+mana_cost = ["1","W","U"]
 color_identity = "UW"
 types = ["creature"]
-tags = ["Spirits - Enabler","Spirits - Payoff","Ninjutsu - Enabler","Tier 4"]
+tags = ["Spirits - Enabler","ETB - Payoff","Signpost","Tier 2"]
 
 ["Spellgorger Weird"]
 mana_cost = ["2","R"]
@@ -1785,6 +1761,12 @@ mana_cost = ["3","G"]
 color_identity = "G"
 types = ["instant"]
 tags = ["Tokens - Enabler","Flash - Threat","Tier 3"]
+
+["Squirrel Wrangler"]
+mana_cost = ["2","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","Land Graveyard - Enabler","Tier 3"]
 
 ["Steel Overseer"]
 mana_cost = ["2"]
@@ -1946,7 +1928,7 @@ tags = ["Trick","Heroic - Enabler","Keyword","Spells - Enabler","Tier 3"]
 mana_cost = ["4","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tokens - Enabler","Tokens - Payoff","Signpost","Tier 3"]
+tags = ["Tokens - Enabler","Tokens - Payoff","Signpost","Tier 3","Keyword"]
 
 ["Tenth District Legionnaire"]
 mana_cost = ["R","W"]
@@ -1958,7 +1940,7 @@ tags = ["Signpost","Tier 2","Heroic - Payoff"]
 mana_cost = ["2","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Big","Keyword","Tier 2"]
+tags = ["Big","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Teysa, Orzhov Scion"]
 mana_cost = ["1","W","B"]
@@ -2002,6 +1984,12 @@ color_identity = "B"
 types = ["creature"]
 tags = ["Ninjutsu - Payoff","Removal","Tier 2"]
 
+["Throatseeker"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff","Tier 3","Vampires - Enabler"]
+
 ["Tilling Treefolk"]
 mana_cost = ["2","G"]
 color_identity = "G"
@@ -2030,7 +2018,7 @@ tags = ["Land Graveyard - Payoff","Signpost","Tier 2","Spice"]
 mana_cost = ["W","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Spice","Tier 1","Counters - Enabler","Counters - Payoff"]
+tags = ["Spice","Tier 1","Counters - Enabler","Counters - Payoff","Keyword"]
 
 ["Tower Geist"]
 mana_cost = ["3","U"]
@@ -2104,6 +2092,12 @@ color_identity = "B"
 types = ["enchantment"]
 tags = ["Lifegain - Enabler","Sacrifice - Payoff","Card Draw","Tier 2"]
 
+["Venerated Loxodon"]
+mana_cost = ["4","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Tier 1","Counters - Enabler","Tokens - Payoff"]
+
 ["Vengeful Rebel"]
 mana_cost = ["2","B"]
 color_identity = "B"
@@ -2132,7 +2126,7 @@ tags = ["Lifegain - Enabler","Lifegain - Payoff","Wizards - Enabler","Tier 2"]
 mana_cost = ["3","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Signpost","Vampires - Enabler","Tier 1","Spice","Madness/Hellbent - Payoff","Sacrifice - Payoff"]
+tags = ["Signpost","Vampires - Enabler","Tier 1","Spice","Madness/Hellbent - Payoff","Sacrifice - Payoff","Keyword"]
 
 ["Voyage's End"]
 mana_cost = ["1","U"]
@@ -2193,6 +2187,12 @@ mana_cost = []
 color_identity = "C"
 types = ["land"]
 tags = []
+
+["Yavimaya Sapherd"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","Tier 3"]
 
 ["Young Pyromancer"]
 mana_cost = ["1","R"]

--- a/mtg_draft_ai/api.py
+++ b/mtg_draft_ai/api.py
@@ -17,6 +17,7 @@ class Card:
                 Currently, only two-part tags are supported, in the format: <Category> - <Subcategory>
                 e.g.: Lifegain - Payoff
                 Defaults to [].
+            power_tier (int): Power level tier as tagged by cube maintainer (currently values 1-4 allowed).
         """
         tags = [] if tags is None else tags
 
@@ -46,6 +47,9 @@ class Card:
         power_tier = None
 
         for raw_tag in raw_tags:
+            # Currently, the only tags we use are:
+            # - power level tags in the format: "Tier N"
+            # - synergy tags in the format: "Theme - Role"
             if raw_tag.startswith('Tier'):
                 power_tier = int(raw_tag.split(' ')[1])
             else:

--- a/mtg_draft_ai/api.py
+++ b/mtg_draft_ai/api.py
@@ -7,7 +7,7 @@ import toml
 class Card:
     """Identifying information and other relevant attributes of a single Magic card."""
 
-    def __init__(self, name, color_id=None, tags=None):
+    def __init__(self, name, color_id=None, tags=None, power_tier=None):
         """
         Args:
             name (str): The card's name.
@@ -23,6 +23,7 @@ class Card:
         self.name = name
         self.color_id = color_id
         self.tags = tags
+        self.power_tier = power_tier
 
     def __str__(self):
         return 'C: {}'.format(self.name)
@@ -42,15 +43,18 @@ class Card:
     def from_raw_data(name, properties):
         raw_tags = properties['tags']
         tags = []
-        for raw_tag in raw_tags:
-            split = raw_tag.split('-')
-            if len(split) != 2:
-                # Currently, only two-part tags are supported
-                continue
-            k, v = split
-            tags.append((k.strip(), v.strip()))
+        power_tier = None
 
-        return Card(name, color_id=properties['color_identity'], tags=tags)
+        for raw_tag in raw_tags:
+            if raw_tag.startswith('Tier'):
+                power_tier = int(raw_tag.split(' ')[1])
+            else:
+                split = raw_tag.split('-')
+                if len(split) == 2:
+                    k, v = split
+                    tags.append((k.strip(), v.strip()))
+
+        return Card(name, color_id=properties['color_identity'], tags=tags, power_tier=power_tier)
 
 
 class Drafter:

--- a/mtg_draft_ai/brains.py
+++ b/mtg_draft_ai/brains.py
@@ -1,7 +1,6 @@
 """Implementations of Picker, which (hopefully) use intelligent strategies to make draft picks."""
 
 import collections
-import math
 import random
 import networkx as nx
 from mtg_draft_ai import synergy
@@ -104,7 +103,6 @@ class GreedySynergyPicker(Picker):
 
                 # Measure of improvement of future pick quality based on common neighbors between pool and candidate.
                 common_neighbors_weighted = self._common_neighbors_weighted(on_color_cards, candidate, color_combo)
-                # common_neighbors = self._common_neighbors(on_color_cards, candidate, color_combo)
 
                 edges_delta = syn_graph.degree[candidate] if candidate in syn_graph else 0
 
@@ -264,7 +262,3 @@ def all_common_neighbors(graph, cards):
             common_neighbors[c2][c1] = neighbors
 
     return common_neighbors
-
-
-def sigmoid(x, k=0.5, x0=5):
-    return round(1 / (1 + math.exp(-k * (x - x0))), 3)

--- a/mtg_draft_ai/brains.py
+++ b/mtg_draft_ai/brains.py
@@ -221,13 +221,13 @@ class GreedyPowerAndSynergyPicker(GreedySynergyPicker):
             color_combo = synergy_rating.color_combo
 
             normalized_values = {k: _normalize(v, max_values[k]) for k, v in raws.items()}
-            power_delta = raws['power_delta']  # don't normalize power since it's already in [0, 1]
+            power_delta = normalized_values['power_delta']
             total_power = normalized_values['total_power']
             edges_delta = normalized_values['edges_delta']
             total_edges = normalized_values['total_edges']
             common_neighbors_weighted = normalized_values['common_neighbors_weighted']
 
-            rating = round(power_delta + total_power + edges_delta + total_edges + common_neighbors_weighted, 3)
+            rating = round(0.5 * ((power_delta + total_power)/2 + (edges_delta + total_edges + common_neighbors_weighted)/3), 3)
 
             final_ratings.append(_CombinedRating(card, color_combo, rating, power_delta, total_power,
                                                  edges_delta, total_edges, common_neighbors_weighted, raws))

--- a/mtg_draft_ai/brains.py
+++ b/mtg_draft_ai/brains.py
@@ -1,6 +1,7 @@
 """Implementations of Picker, which (hopefully) use intelligent strategies to make draft picks."""
 
 import collections
+import math
 import random
 import networkx as nx
 from mtg_draft_ai import synergy
@@ -38,10 +39,6 @@ class Factory:
         return self.output_class(**self.kwargs)
 
 
-_GSPRating = collections.namedtuple('Rating', ['card', 'color_combo', 'total_edges',
-                                               'common_neighbors_weighted', 'default'])
-
-
 class GreedySynergyPicker(Picker):
     """Attempts to maximize number of synergy edges, for the color pair with the most edges in its pool."""
 
@@ -57,8 +54,8 @@ class GreedySynergyPicker(Picker):
         self.default_ratings = default_ratings
         self.common_neighbors = common_neighbors
 
-    @staticmethod
-    def factory(card_list):
+    @classmethod
+    def factory(cls, card_list):
         """Creates a factory for GreedySynergyPicker instances.
 
         Performs potentially expensive precomputations, which can be reused to create multiple instances.
@@ -80,7 +77,7 @@ class GreedySynergyPicker(Picker):
 
         kwargs = {'default_ratings': defaults,
                   'common_neighbors': common_neighbors}
-        return Factory(GreedySynergyPicker, kwargs)
+        return Factory(cls, kwargs)
 
     def pick(self, pack, cards_owned, draft_info):
         ranked_candidates = self._ratings(pack, cards_owned, draft_info)
@@ -107,9 +104,14 @@ class GreedySynergyPicker(Picker):
 
                 # Measure of improvement of future pick quality based on common neighbors between pool and candidate.
                 common_neighbors_weighted = self._common_neighbors_weighted(on_color_cards, candidate, color_combo)
+                # common_neighbors = self._common_neighbors(on_color_cards, candidate, color_combo)
+
+                edges_delta = syn_graph.degree[candidate] if candidate in syn_graph else 0
+
                 default = self.default_ratings[candidate]
 
-                candidates.append(_GSPRating(candidate, color_combo, total_edges, common_neighbors_weighted, default))
+                candidates.append(_GSPRating(candidate, color_combo, total_edges, common_neighbors_weighted,
+                                             edges_delta, default))
 
         # Lexicographic sort of the fields in the rating tuple (excluding the card and color combo)
         candidates.sort(key=lambda tup: tup[2:], reverse=True)
@@ -126,6 +128,112 @@ class GreedySynergyPicker(Picker):
             neighbor_count += len(valid_neighbors)
 
         return neighbor_count
+
+    def _common_neighbors(self, card_pool, candidate, colors):
+        """Sums # of common neighbors between candidate and each card in the pool."""
+
+        neighbors = set()
+
+        for c in card_pool:
+            valid_neighbors = [n.name for n in self.common_neighbors[candidate][c]
+                               if synergy.castable(n, colors)
+                               if n not in card_pool]
+            neighbors.update(valid_neighbors)
+
+        return len(neighbors)
+
+
+_GSPRating = collections.namedtuple('Rating', ['card', 'color_combo', 'total_edges',
+                                               'common_neighbors_weighted', 'edges_delta', 'default'])
+
+
+_CombinedRating = collections.namedtuple('CombinedRating', ['card', 'color_combo', 'rating',
+                                                            'power_delta', 'total_power', 'edges_delta', 'total_edges',
+                                                            'raw_values'])
+
+
+class GreedyPowerAndSynergyPicker(GreedySynergyPicker):
+
+    def pick(self, pack, cards_owned, draft_info):
+        synergy_ratings = self._ratings(pack, cards_owned, draft_info)
+        combined_ratings = GreedyPowerAndSynergyPicker._combined_ratings(synergy_ratings, cards_owned)
+        combined_ratings.sort(key=lambda cr: cr.rating, reverse=True)
+
+        # replace full card object with just card name for more readable output
+        printable_candidates = [str(_CombinedRating(tup[0].name, *tup[1:])) for tup in combined_ratings]
+        print('\nrankings:\n{}'.format('\n'.join(printable_candidates)))
+
+        return pack[0] if len(combined_ratings) == 0 else combined_ratings[0].card
+
+    @classmethod
+    def _combined_ratings(cls, synergy_ratings, cards_owned):
+        pool_total_power_by_color_pair = {}
+        for color_pair in COLOR_PAIRS:
+            on_color_cards = [c for c in cards_owned if synergy.castable(c, color_pair)]
+            total_power = sum([cls._power_rating(c) for c in on_color_cards])
+            pool_total_power_by_color_pair[color_pair] = total_power
+
+        raw_ratings = []
+        for r in synergy_ratings:
+            power_delta = cls._power_rating(r.card)
+            # round to correct for floating point arithmetic imprecision
+            total_power = round(pool_total_power_by_color_pair[r.color_combo] + power_delta, 2)
+
+            raw_values = {'power_delta': power_delta, 'total_power': total_power,
+                          'edges_delta': r.edges_delta, 'total_edges': r.total_edges}
+
+            raw_ratings.append((r, raw_values))
+
+        return cls._normalize_ratings(raw_ratings)
+
+    @staticmethod
+    def _power_rating(card):
+        values_by_tier = {
+            1: 1,
+            2: 0.8,
+            3: 0.6,
+            4: 0.3,
+            None: 0
+        }
+        if card.power_tier not in values_by_tier:
+            raise ValueError('Undefined power tier: {}'.format(card.power_tier))
+        return values_by_tier[card.power_tier]
+
+    @staticmethod
+    def _normalize_ratings(raw_ratings):
+        if not raw_ratings:
+            return []
+
+        synergy_ratings, raw_values = zip(*raw_ratings)
+
+        # all elements should have the same fields
+        fields = raw_values[0].keys()
+
+        max_values = {}
+        for field in fields:
+            max_values[field] = max([rv[field] for rv in raw_values])
+
+        final_ratings = []
+
+        for synergy_rating, raws in raw_ratings:
+            card = synergy_rating.card
+            color_combo = synergy_rating.color_combo
+
+            normalized_values = {k: _normalize(v, max_values[k]) for k, v in raws.items()}
+            power_delta = raws['power_delta']  # don't normalize power since it's already in [0, 1]
+            total_power = normalized_values['total_power']
+            edges_delta = normalized_values['edges_delta']
+            total_edges = normalized_values['total_edges']
+
+            rating = round(power_delta + total_power + edges_delta + total_edges, 3)
+
+            final_ratings.append(_CombinedRating(card, color_combo, rating, power_delta, total_power,
+                                                 edges_delta, total_edges, raws))
+        return final_ratings
+
+
+def _normalize(value, max_value):
+    return round(value / max_value, 3) if max_value != 0 else 0
 
 
 def all_common_neighbors(graph, cards):
@@ -154,3 +262,7 @@ def all_common_neighbors(graph, cards):
             common_neighbors[c2][c1] = neighbors
 
     return common_neighbors
+
+
+def sigmoid(x, k=0.5, x0=5):
+    return round(1 / (1 + math.exp(-k * (x - x0))), 3)

--- a/mtg_draft_ai/brains.py
+++ b/mtg_draft_ai/brains.py
@@ -149,7 +149,7 @@ _GSPRating = collections.namedtuple('Rating', ['card', 'color_combo', 'total_edg
 
 _CombinedRating = collections.namedtuple('CombinedRating', ['card', 'color_combo', 'rating',
                                                             'power_delta', 'total_power', 'edges_delta', 'total_edges',
-                                                            'raw_values'])
+                                                            'common_neighbors_weighted', 'raw_values'])
 
 
 class GreedyPowerAndSynergyPicker(GreedySynergyPicker):
@@ -180,7 +180,8 @@ class GreedyPowerAndSynergyPicker(GreedySynergyPicker):
             total_power = round(pool_total_power_by_color_pair[r.color_combo] + power_delta, 2)
 
             raw_values = {'power_delta': power_delta, 'total_power': total_power,
-                          'edges_delta': r.edges_delta, 'total_edges': r.total_edges}
+                          'edges_delta': r.edges_delta, 'total_edges': r.total_edges,
+                          'common_neighbors_weighted': r.common_neighbors_weighted}
 
             raw_ratings.append((r, raw_values))
 
@@ -224,11 +225,12 @@ class GreedyPowerAndSynergyPicker(GreedySynergyPicker):
             total_power = normalized_values['total_power']
             edges_delta = normalized_values['edges_delta']
             total_edges = normalized_values['total_edges']
+            common_neighbors_weighted = normalized_values['common_neighbors_weighted']
 
-            rating = round(power_delta + total_power + edges_delta + total_edges, 3)
+            rating = round(power_delta + total_power + edges_delta + total_edges + common_neighbors_weighted, 3)
 
             final_ratings.append(_CombinedRating(card, color_combo, rating, power_delta, total_power,
-                                                 edges_delta, total_edges, raws))
+                                                 edges_delta, total_edges, common_neighbors_weighted, raws))
         return final_ratings
 
 

--- a/notebooks/cube_81183_tag_data.toml
+++ b/notebooks/cube_81183_tag_data.toml
@@ -2,19 +2,13 @@
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler"]
+tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler","Tier 2","Ramp - Payoff"]
 
 ["Abzan Battle Priest"]
 mana_cost = ["3","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Payoff","Keyword","Lifegain - Enabler","Counters - Enabler"]
-
-["Accorder Paladin"]
-mana_cost = ["1","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Tokens - Payoff","Keyword"]
+tags = ["Counters - Payoff","Keyword","Lifegain - Enabler","Counters - Enabler","Tier 3"]
 
 ["Adarkar Wastes"]
 mana_cost = []
@@ -26,127 +20,115 @@ tags = []
 mana_cost = ["1","U","R"]
 color_identity = "UR"
 types = ["creature"]
-tags = ["Spells - Payoff","Wizards - Payoff","Wizards - Enabler"]
+tags = ["Spells - Payoff","Wizards - Payoff","Wizards - Enabler","Tier 1"]
 
 ["Ajani's Pridemate"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Lifegain - Payoff"]
+tags = ["Lifegain - Payoff","Tier 3"]
 
 ["Akroan Crusader"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Heroic - Payoff","Keyword"]
+tags = ["Heroic - Payoff","Keyword","Tier 4"]
 
 ["Anafenza, Kin-Tree Spirit"]
 mana_cost = ["W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Enabler","Keyword","Spirits - Enabler","ETB - Enabler"]
+tags = ["Counters - Enabler","Keyword","Spirits - Enabler","ETB - Enabler","Tier 1"]
 
 ["Anax and Cymede"]
 mana_cost = ["1","W","R"]
 color_identity = "RW"
 types = ["creature"]
-tags = ["Signpost","Heroic - Payoff","Keyword"]
+tags = ["Signpost","Heroic - Payoff","Keyword","Tier 1"]
 
 ["Angel of Flight Alabaster"]
 mana_cost = ["4","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Signpost","Spirits - Payoff"]
+tags = ["Signpost","Spirits - Payoff","Tier 2"]
 
 ["Angelic Gift"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Heroic - Enabler"]
-
-["Anowon, the Ruin Sage"]
-mana_cost = ["3","B","B"]
-color_identity = "B"
-types = ["creature"]
-tags = ["Vampires - Enabler","Vampires - Payoff","Sacrifice - Payoff","Signpost"]
-
-["Arcbond"]
-mana_cost = ["2","R"]
-color_identity = "R"
-types = ["instant"]
-tags = ["Spells - Enabler"]
-
-["Arena Athlete"]
-mana_cost = ["1","R"]
-color_identity = "R"
-types = ["creature"]
-tags = ["Heroic - Payoff","Keyword"]
+tags = ["Heroic - Enabler","Tier 3"]
 
 ["Armorcraft Judge"]
 mana_cost = ["3","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Signpost","Counters - Payoff","Card Draw"]
+tags = ["Signpost","Counters - Payoff","Card Draw","Tier 2","Spice"]
 
 ["Artificer's Assistant"]
 mana_cost = ["U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Ninjutsu - Enabler","Artifacts (Cheap) - Payoff"]
+tags = ["Ninjutsu - Enabler","Artifacts (Cheap) - Payoff","Tier 4"]
 
 ["Asylum Visitor"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Keyword","Vampires - Enabler","Wizards - Enabler","Card Draw","Madness/Hellbent - Payoff"]
+tags = ["Keyword","Vampires - Enabler","Wizards - Enabler","Card Draw","Madness/Hellbent - Payoff","Tier 3"]
 
 ["Augury Owl"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["ETB - Enabler","Ninjutsu - Enabler"]
+tags = ["ETB - Enabler","Ninjutsu - Enabler","Tier 3"]
+
+["Avacyn's Judgment"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["sorcery"]
+tags = ["Signpost","Madness/Hellbent - Payoff","Spells - Enabler","Removal - Size","Removal","Tier 3","Keyword"]
+
+["Avaricious Dragon"]
+mana_cost = ["2","R","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Madness/Hellbent - Enabler","Madness/Hellbent - Payoff","Tier 3"]
 
 ["Ayli, Eternal Pilgrim"]
 mana_cost = ["W","B"]
 color_identity = "BW"
 types = ["creature"]
-tags = ["Signpost","Lifegain - Enabler","Lifegain - Payoff","Higher Toughness"]
+tags = ["Signpost","Lifegain - Enabler","Lifegain - Payoff","Higher Toughness","Tier 1","Spice","Noncreature Permanent Interaction"]
 
 ["Azami, Lady of Scrolls"]
 mana_cost = ["2","U","U","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Signpost","Wizards - Payoff","Wizards - Enabler","Card Draw"]
-
-["Azorius Herald"]
-mana_cost = ["2","W"]
-color_identity = "UW"
-types = ["creature"]
-tags = ["Spirits - Enabler","Lifegain - Enabler","ETB - Enabler"]
+tags = ["Signpost","Wizards - Payoff","Wizards - Enabler","Card Draw","Tier 1"]
 
 ["Azorius Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Azra Oddsmaker"]
 mana_cost = ["1","B","R"]
 color_identity = "BR"
 types = ["creature"]
-tags = ["Card Draw","Madness/Hellbent - Enabler"]
+tags = ["Card Draw","Madness/Hellbent - Enabler","Tier 1","Spice"]
+
+["Bandage"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["instant"]
+tags = ["Tier 2","Heroic - Enabler"]
 
 ["Banisher Priest"]
 mana_cost = ["1","W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Removal","ETB - Enabler"]
-
-["Banishing Light"]
-mana_cost = ["2","W"]
-color_identity = "W"
-types = ["enchantment"]
-tags = ["Removal"]
+tags = ["Removal","ETB - Enabler","Tier 2"]
 
 ["Battlefield Forge"]
 mana_cost = []
@@ -158,127 +140,121 @@ tags = []
 mana_cost = ["6","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword","Card Draw"]
+tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword","Card Draw","Tier 1","Spice"]
 
 ["Birds of Paradise"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Ninjutsu - Enabler"]
+tags = ["Ninjutsu - Enabler","Tier 1","Ramp - Enabler"]
 
 ["Bishop of Rebirth"]
 mana_cost = ["3","W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Higher Toughness","Vampires - Enabler"]
+tags = ["Higher Toughness","Vampires - Enabler","Tier 3"]
 
 ["Blade of the Bloodchief"]
 mana_cost = ["1"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Counters - Enabler","Sacrifice - Payoff","Vampires - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
-
-["Blighted Gorge"]
-mana_cost = []
-color_identity = "R"
-types = ["land"]
-tags = ["Land Graveyard - Enabler"]
-
-["Blood Artist"]
-mana_cost = ["1","B"]
-color_identity = "B"
-types = ["creature"]
-tags = ["Sacrifice - Payoff","Vampires - Enabler","Lifegain - Enabler"]
+tags = ["Counters - Enabler","Sacrifice - Payoff","Vampires - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
 
 ["Bloodhall Priest"]
 mana_cost = ["2","B","R"]
 color_identity = "BR"
 types = ["creature"]
-tags = ["Signpost","Big","Keyword","Vampires - Enabler","Madness/Hellbent - Payoff"]
+tags = ["Signpost","Big","Keyword","Vampires - Enabler","Madness/Hellbent - Payoff","Tier 1"]
 
 ["Bloodline Necromancer"]
 mana_cost = ["4","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Payoff","Vampires - Enabler","Wizards - Payoff","Wizards - Enabler"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Payoff","Vampires - Enabler","Wizards - Payoff","Wizards - Enabler","Tier 1","Spice"]
+
+["Bloodmist Infiltrator"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Vampires - Enabler","Tier 3","cuttable"]
 
 ["Bloodrage Brawler"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Madness/Hellbent - Enabler"]
+tags = ["Madness/Hellbent - Enabler","Tier 3"]
 
 ["Bloodsoaked Champion"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Keyword"]
+tags = ["Sacrifice - Enabler","Keyword","Tier 2"]
 
 ["Bloodspore Thrinax"]
 mana_cost = ["2","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","Tokens - Payoff","Keyword","Sacrifice - Payoff"]
+tags = ["Counters - Enabler","Tokens - Payoff","Keyword","Sacrifice - Payoff","Tier 3"]
 
 ["Blossoming Defense"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler"]
+tags = ["Trick","Heroic - Enabler","Flash - Interaction","Tier 2"]
 
 ["Bomat Courier"]
 mana_cost = ["1"]
 color_identity = "R"
 types = ["artifact","creature"]
-tags = ["Madness/Hellbent - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Madness/Hellbent - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2"]
 
 ["Bone Picker"]
 mana_cost = ["3","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Payoff","Ninjutsu - Enabler"]
+tags = ["Sacrifice - Payoff","Ninjutsu - Enabler","Tier 3"]
 
 ["Bone Splinters"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["sorcery"]
-tags = ["Removal","Sacrifice - Payoff"]
+tags = ["Removal","Sacrifice - Payoff","Tier 4"]
 
 ["Boros Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Bound by Moonsilver"]
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Removal","Keyword","Heroic - Enabler"]
+tags = ["Removal","Keyword","Heroic - Enabler","Tier 2"]
 
 ["Bounding Krasis"]
 mana_cost = ["1","U","G"]
 color_identity = "GU"
 types = ["creature"]
-tags = ["Flash - Threat"]
+tags = ["Flash - Threat","Tier 2"]
 
 ["Brago, King Eternal"]
 mana_cost = ["2","W","U"]
 color_identity = "UW"
 types = ["creature"]
-tags = ["Signpost","ETB - Payoff","Spirits - Enabler","Higher Toughness"]
+tags = ["Signpost","ETB - Payoff","Spirits - Enabler","Higher Toughness","Tier 1","Spice"]
 
 ["Brimstone Volley"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Removal","Keyword","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Keyword","Spells - Enabler","Removal - Size","Tier 2"]
 
 ["Brittle Effigy"]
 mana_cost = ["1"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Removal","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Removal","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
 
 ["Brushland"]
 mana_cost = []
@@ -290,25 +266,37 @@ tags = []
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Land Graveyard - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Creature) - Payoff"]
+tags = ["Land Graveyard - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Creature) - Payoff","Tier 3"]
+
+["Burning Prophet"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Tier 2","Spells - Payoff","Wizards - Enabler","Artifacts (Noncreature) - Payoff"]
 
 ["Call to the Feast"]
 mana_cost = ["2","W","B"]
 color_identity = "BW"
 types = ["sorcery"]
-tags = ["Tokens - Enabler","Lifegain - Enabler","Vampires - Enabler"]
+tags = ["Tokens - Enabler","Lifegain - Enabler","Vampires - Enabler","Tier 3"]
+
+["Camaraderie"]
+mana_cost = ["4","G","W"]
+color_identity = "GW"
+types = ["sorcery"]
+tags = ["Spice","Tier 2","Signpost","Tokens - Payoff"]
 
 ["Cathartic Reunion"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["sorcery"]
-tags = ["Graveyard - Enabler","Spells - Enabler","Madness/Hellbent - Enabler"]
+tags = ["Graveyard - Enabler","Spells - Enabler","Madness/Hellbent - Enabler","Tier 2"]
 
 ["Cavern Harpy"]
 mana_cost = ["U","B"]
 color_identity = "BU"
 types = ["creature"]
-tags = ["ETB - Payoff","Ninjutsu - Enabler"]
+tags = ["ETB - Payoff","Ninjutsu - Enabler","Tier 2","Spice"]
 
 ["Caves of Koilos"]
 mana_cost = []
@@ -316,17 +304,23 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
+["Celestial Kirin"]
+mana_cost = ["2","W","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Spirits - Enabler","Spirits - Payoff","Tier 2","Spice"]
+
 ["Centaur's Herald"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Flash - Threat"]
+tags = ["Flash - Threat","Tier 3"]
 
 ["Chart a Course"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["sorcery"]
-tags = ["Graveyard - Enabler","Keyword","Card Draw","Spells - Enabler","Madness/Hellbent - Enabler"]
+tags = ["Graveyard - Enabler","Keyword","Card Draw","Spells - Enabler","Madness/Hellbent - Enabler","Tier 2"]
 
 ["Cinder Barrens"]
 mana_cost = []
@@ -344,163 +338,169 @@ tags = []
 mana_cost = ["3","W","U"]
 color_identity = "UW"
 types = ["creature"]
-tags = ["Lifegain - Enabler","ETB - Enabler","Card Draw"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Card Draw","Tier 1"]
 
 ["Cloudfin Raptor"]
 mana_cost = ["U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Counters - Enabler","Keyword","Ninjutsu - Enabler"]
+tags = ["Counters - Enabler","Keyword","Ninjutsu - Enabler","Tier 1"]
 
 ["Collateral Damage"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Sacrifice - Payoff","Removal","Spells - Enabler","Removal - Size"]
+tags = ["Sacrifice - Payoff","Removal","Spells - Enabler","Removal - Size","Tier 4"]
+
+["Command the Dreadhorde"]
+mana_cost = ["4","B","B"]
+color_identity = "B"
+types = ["sorcery"]
+tags = ["Tier 2","Spice","Lifegain - Payoff"]
 
 ["Commune with the Gods"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["sorcery"]
-tags = ["Graveyard - Enabler"]
+tags = ["Graveyard - Enabler","Tier 2"]
+
+["Conclave Tribunal"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Tier 2","Removal","Tokens - Payoff"]
 
 ["Countryside Crusher"]
 mana_cost = ["1","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Land Graveyard - Payoff","Land Graveyard - Enabler","Big"]
+tags = ["Tier 3","Land Graveyard - Enabler","Land Graveyard - Payoff"]
 
 ["Crawling Sensation"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["enchantment"]
-tags = ["Graveyard - Enabler","Land Graveyard - Payoff"]
-
-["Crested Herdcaller"]
-mana_cost = ["3","G","G"]
-color_identity = "G"
-types = ["creature"]
-tags = ["Tokens - Enabler","ETB - Enabler"]
+tags = ["Graveyard - Enabler","Land Graveyard - Payoff","Tier 4"]
 
 ["Crested Sunmare"]
 mana_cost = ["3","W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Signpost","Lifegain - Payoff","Big"]
+tags = ["Signpost","Lifegain - Payoff","Big","Tier 1","Spice"]
 
 ["Crovax the Cursed"]
 mana_cost = ["2","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Signpost","Sacrifice - Payoff","Counters - Enabler","Big","Vampires - Enabler"]
-
-["Crusader of Odric"]
-mana_cost = ["2","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Tokens - Payoff","Big"]
+tags = ["Signpost","Sacrifice - Payoff","Counters - Enabler","Big","Vampires - Enabler","Tier 2"]
 
 ["Crush of Tentacles"]
 mana_cost = ["4","U","U"]
 color_identity = "U"
 types = ["sorcery"]
-tags = ["Big","Keyword","ETB - Payoff"]
+tags = ["Big","Keyword","ETB - Payoff","Tier 1","Spice"]
 
 ["Crux of Fate"]
 mana_cost = ["3","B","B"]
 color_identity = "B"
 types = ["sorcery"]
-tags = []
+tags = ["Tier 1"]
 
 ["Cryptic Serpent"]
 mana_cost = ["5","U","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Spells - Payoff"]
+tags = ["Spells - Payoff","Tier 3"]
+
+["Cryptolith Rite"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["enchantment"]
+tags = ["Tier 2","Spice","Tokens - Payoff"]
 
 ["Cultivator's Caravan"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Big","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Big","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Creature) - Enabler","Tier 3"]
 
 ["Curious Obsession"]
 mana_cost = ["U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Card Draw"]
-
-["Daring Archaeologist"]
-mana_cost = ["3","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Big","Keyword","ETB - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Creature) - Payoff"]
+tags = ["Heroic - Enabler","Card Draw","Tier 1"]
 
 ["Dark-Dweller Oracle"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Sacrifice - Payoff"]
+tags = ["Sacrifice - Payoff","Tier 2","Spice"]
 
 ["Deadbridge Chant"]
 mana_cost = ["4","B","G"]
 color_identity = "BG"
 types = ["enchantment"]
-tags = ["Signpost","Graveyard - Enabler","Card Draw"]
+tags = ["Signpost","Graveyard - Enabler","Card Draw","Tier 3"]
 
 ["Deadeye Harpooner"]
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["ETB - Enabler","Removal"]
+tags = ["ETB - Enabler","Removal","Tier 3"]
 
 ["Devoted Druid"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = []
+tags = ["Tier 2","Ramp - Enabler"]
 
 ["Dimir Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Dinrova Horror"]
 mana_cost = ["4","U","B"]
 color_identity = "BU"
 types = ["creature"]
-tags = ["ETB - Enabler","Bounce"]
+tags = ["ETB - Enabler","Bounce","Tier 3","Noncreature Permanent Interaction"]
 
 ["Dismissive Pyromancer"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Removal","Wizards - Enabler","Madness/Hellbent - Enabler","Graveyard - Enabler","Removal - Size"]
+tags = ["Removal","Wizards - Enabler","Madness/Hellbent - Enabler","Graveyard - Enabler","Removal - Size","Tier 2"]
 
 ["Disperse"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Bounce","Spells - Enabler"]
+tags = ["Bounce","Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent Interaction"]
 
 ["Dissolve"]
 mana_cost = ["1","U","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Flash - Counterspell","Spells - Enabler"]
+tags = ["Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent Interaction"]
 
 ["Dive Down"]
 mana_cost = ["U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler","Spells - Enabler"]
+tags = ["Trick","Heroic - Enabler","Spells - Enabler","Flash - Interaction","Tier 2"]
+
+["Divine Visitation"]
+mana_cost = ["3","W","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Signpost","Spice","Tier 2","Tokens - Payoff"]
 
 ["Dragon Mantle"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["enchantment"]
-tags = ["Heroic - Enabler"]
+tags = ["Heroic - Enabler","Tier 3"]
 
 ["Dragonskull Summit"]
 mana_cost = []
@@ -512,7 +512,13 @@ tags = []
 mana_cost = ["2","U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Signpost","Madness/Hellbent - Payoff"]
+tags = ["Signpost","Madness/Hellbent - Payoff","Tier 3","Spice"]
+
+["Drogskol Captain"]
+mana_cost = ["1","W","U"]
+color_identity = "UW"
+types = ["creature"]
+tags = ["Signpost","Tier 2","Spirits - Enabler","Spirits - Payoff"]
 
 ["Drowned Catacomb"]
 mana_cost = []
@@ -524,103 +530,97 @@ tags = []
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["ETB - Enabler","Vampires - Enabler"]
-
-["Echoing Decay"]
-mana_cost = ["1","B"]
-color_identity = "B"
-types = ["instant"]
-tags = ["Removal","Removal - Size"]
-
-["Embodiment of Fury"]
-mana_cost = ["3","R"]
-color_identity = "R"
-types = ["creature"]
-tags = ["Land Graveyard - Enabler","Landfall - Payoff","Keyword"]
+tags = ["ETB - Enabler","Vampires - Enabler","Tier 3"]
 
 ["Enthralling Victor"]
 mana_cost = ["3","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","ETB - Enabler"]
+tags = ["Sacrifice - Enabler","ETB - Enabler","Tier 3"]
 
 ["Epiphany at the Drownyard"]
 mana_cost = ["X","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler"]
+tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler","Flash - Threat","Tier 3","Ramp - Payoff"]
 
 ["Essence Flux"]
 mana_cost = ["U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Trick","Spirits - Payoff","Spells - Enabler"]
+tags = ["Trick","Spirits - Payoff","Spells - Enabler","Tier 4","cuttable"]
 
 ["Experiment One"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","Keyword"]
+tags = ["Counters - Enabler","Keyword","Tier 3"]
 
 ["Fa'adiyah Seer"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Landfall - Enabler","Graveyard - Enabler","Madness/Hellbent - Enabler"]
+tags = ["Landfall - Enabler","Graveyard - Enabler","Madness/Hellbent - Enabler","Tier 3"]
 
 ["Fall of the Titans"]
 mana_cost = ["X","X","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Removal","Heroic - Enabler","Keyword","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Heroic - Enabler","Keyword","Spells - Enabler","Removal - Size","Tier 1","Ramp - Payoff"]
 
 ["Familiar's Ruse"]
 mana_cost = ["U","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Flash - Counterspell"]
+tags = ["Flash - Interaction","Tier 3","Noncreature Permanent Interaction"]
 
 ["Favored Hoplite"]
 mana_cost = ["W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Heroic - Payoff","Higher Toughness","Keyword"]
+tags = ["Heroic - Payoff","Higher Toughness","Keyword","Tier 2"]
 
 ["Fettergeist"]
 mana_cost = ["2","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Higher Toughness","Spirits - Enabler","Ninjutsu - Enabler"]
+tags = ["Higher Toughness","Spirits - Enabler","Ninjutsu - Enabler","Tier 3"]
 
 ["Fiery Temper"]
 mana_cost = ["1","R","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Keyword","Spells - Enabler","Madness/Hellbent - Payoff","Removal","Removal - Size"]
+tags = ["Keyword","Spells - Enabler","Madness/Hellbent - Payoff","Removal","Removal - Size","Tier 3"]
 
 ["Filigree Familiar"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Lifegain - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Lifegain - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
+
+["Fireblade Artist"]
+mana_cost = ["B","R"]
+color_identity = "BR"
+types = ["creature"]
+tags = ["Sacrifice - Payoff","Tier 3"]
+
+["Fists of Flame"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Heroic - Enabler","Spells - Enabler","Tier 2","Spice","Trick"]
 
 ["Fists of Ironwood"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["enchantment"]
-tags = ["Tokens - Enabler","Heroic - Enabler"]
+tags = ["Tokens - Enabler","Heroic - Enabler","Tier 3"]
 
 ["Forsaken Sanctuary"]
 mana_cost = []
 color_identity = "C"
 types = ["land"]
 tags = []
-
-["Fortune's Favor"]
-mana_cost = ["3","U"]
-color_identity = "U"
-types = ["instant"]
-tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler"]
 
 ["Foul Orchard"]
 mana_cost = []
@@ -632,61 +632,55 @@ tags = []
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Tier 3"]
 
 ["Gallant Cavalry"]
 mana_cost = ["3","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["ETB - Enabler","Tokens - Enabler"]
+tags = ["ETB - Enabler","Tokens - Enabler","Tier 3","cuttable"]
 
 ["Gather the Townsfolk"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["sorcery"]
-tags = ["Tokens - Enabler","Keyword","Spells - Enabler"]
-
-["Generator Servant"]
-mana_cost = ["1","R"]
-color_identity = "R"
-types = ["creature"]
-tags = []
+tags = ["Tokens - Enabler","Keyword","Spells - Enabler","Tier 3"]
 
 ["Generous Patron"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword","ETB - Enabler","Card Draw"]
+tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword","ETB - Enabler","Card Draw","Tier 1","Spice"]
 
 ["Genesis Wave"]
 mana_cost = ["X","G","G","G"]
 color_identity = "G"
 types = ["sorcery"]
-tags = ["Big"]
+tags = ["Big","Tier 3","Ramp - Payoff"]
 
 ["Ghitu Lavarunner"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Wizards - Enabler"]
+tags = ["Wizards - Enabler","Tier 4"]
 
 ["Ghoultree"]
 mana_cost = ["7","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Signpost","Graveyard - Payoff","Big"]
+tags = ["Signpost","Graveyard - Payoff","Big","Tier 3"]
 
 ["Gideon's Reproach"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["instant"]
-tags = ["Removal","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Spells - Enabler","Removal - Size","Tier 3"]
 
 ["Gird for Battle"]
 mana_cost = ["W"]
 color_identity = "W"
 types = ["sorcery"]
-tags = ["Heroic - Enabler","Counters - Enabler","Spells - Enabler"]
+tags = ["Heroic - Enabler","Counters - Enabler","Spells - Enabler","Tier 4"]
 
 ["Glacial Fortress"]
 mana_cost = []
@@ -698,145 +692,139 @@ tags = []
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Higher Toughness","ETB - Enabler","Ninjutsu - Enabler","Artifacts - Payoff"]
+tags = ["Higher Toughness","Ninjutsu - Enabler","Artifacts - Payoff","Tier 3"]
 
 ["Goblin Assault"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["enchantment"]
-tags = ["Tokens - Enabler","Sacrifice - Enabler"]
+tags = ["Tokens - Enabler","Sacrifice - Enabler","Tier 4"]
 
 ["Goblin Clearcutter"]
 mana_cost = ["3","R"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Land Graveyard - Enabler"]
+tags = ["Land Graveyard - Enabler","Tier 3","Ramp - Enabler"]
 
 ["Goblin Instigator"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Tokens - Enabler","ETB - Enabler"]
+tags = ["Sacrifice - Enabler","Tokens - Enabler","ETB - Enabler","Tier 3"]
 
 ["Goblin Welder"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Signpost","Artifacts - Payoff"]
+tags = ["Signpost","Artifacts - Payoff","Tier 2","Spice"]
 
 ["Golgari Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Gonti, Lord of Luxury"]
 mana_cost = ["2","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Higher Toughness","ETB - Enabler"]
+tags = ["Higher Toughness","ETB - Enabler","Tier 1"]
 
-["Grab the Reins"]
-mana_cost = ["3","R"]
-color_identity = "R"
-types = ["instant"]
-tags = ["Keyword","Spells - Enabler","Sacrifice - Enabler"]
+["Good-Fortune Unicorn"]
+mana_cost = ["1","G","W"]
+color_identity = "GW"
+types = ["creature"]
+tags = ["Tier 2","Counters - Enabler","Tokens - Payoff"]
+
+["Grateful Apparition"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Counters - Payoff","Spirits - Enabler","Ninjutsu - Enabler","Tier 3","Keyword"]
 
 ["Graveyard Marshal"]
 mana_cost = ["B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Signpost"]
+tags = ["Graveyard - Payoff","Signpost","Tier 2"]
 
 ["Grazing Gladehart"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Landfall - Payoff"]
+tags = ["Lifegain - Enabler","Landfall - Payoff","Tier 3"]
 
 ["Greenwarden of Murasa"]
 mana_cost = ["4","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Big","ETB - Enabler"]
+tags = ["Graveyard - Payoff","Big","ETB - Enabler","Tier 1","Ramp - Payoff"]
 
 ["Gruesome Menagerie"]
 mana_cost = ["3","B","B"]
 color_identity = "B"
 types = ["sorcery"]
-tags = ["Graveyard - Payoff"]
+tags = ["Graveyard - Payoff","Tier 2","Spice"]
 
 ["Gruul Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Gyre Sage"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","Higher Toughness","Keyword"]
+tags = ["Counters - Enabler","Higher Toughness","Keyword","Tier 2"]
+
+["Hanweir Militia Captain"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Tokens - Payoff","Tier 2"]
 
 ["Harbinger of the Tides"]
 mana_cost = ["U","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Bounce","ETB - Enabler","Wizards - Enabler","Flash - Threat"]
+tags = ["Bounce","ETB - Enabler","Wizards - Enabler","Flash - Threat","Tier 2"]
 
 ["Hardened Scales"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["enchantment"]
-tags = ["Counters - Payoff","Signpost"]
-
-["Harm's Way"]
-mana_cost = ["W"]
-color_identity = "W"
-types = ["instant"]
-tags = ["Removal","Heroic - Enabler","Spells - Enabler","Removal - Size"]
+tags = ["Counters - Payoff","Signpost","Tier 2"]
 
 ["Harvest Pyre"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Removal","Graveyard - Payoff","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Graveyard - Payoff","Spells - Enabler","Removal - Size","Tier 3"]
 
 ["Haunted Dead"]
 mana_cost = ["3","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Tokens - Enabler","Graveyard - Payoff","Spirits - Enabler","ETB - Enabler","Madness/Hellbent - Enabler","Sacrifice - Enabler"]
-
-["Hearthfire Hobgoblin"]
-mana_cost = ["RW","RW","RW"]
-color_identity = "RW"
-types = ["creature"]
-tags = []
+tags = ["Tokens - Enabler","Graveyard - Payoff","Spirits - Enabler","ETB - Enabler","Madness/Hellbent - Enabler","Sacrifice - Enabler","Tier 2"]
 
 ["Hedron Archive"]
 mana_cost = ["4"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Tier 2","Ramp - Enabler"]
 
 ["Heir of Falkenrath"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Keyword","Vampires - Enabler","Madness/Hellbent - Enabler"]
-
-["Heir of the Wilds"]
-mana_cost = ["1","G"]
-color_identity = "G"
-types = ["creature"]
-tags = ["Keyword"]
+tags = ["Keyword","Vampires - Enabler","Madness/Hellbent - Enabler","Tier 2"]
 
 ["Hermit Druid"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Enabler","Landfall - Enabler","Land Graveyard - Enabler"]
+tags = ["Graveyard - Enabler","Landfall - Enabler","Land Graveyard - Enabler","Tier 2"]
 
 ["Highland Lake"]
 mana_cost = []
@@ -848,7 +836,7 @@ tags = []
 mana_cost = ["3","U","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Ninjutsu - Payoff","Signpost","Ninjutsu - Enabler","Higher Toughness"]
+tags = ["Ninjutsu - Payoff","Signpost","Ninjutsu - Enabler","Higher Toughness","Tier 2"]
 
 ["Hinterland Harbor"]
 mana_cost = []
@@ -856,53 +844,53 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
-["Hollowhenge Spirit"]
-mana_cost = ["3","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Spirits - Enabler","Flash - Threat"]
-
 ["Hooded Hydra"]
 mana_cost = ["X","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","Counters - Payoff","Tokens - Enabler"]
+tags = ["Counters - Enabler","Counters - Payoff","Tokens - Enabler","Tier 2","Spice"]
 
 ["Hostile Desert"]
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Land Graveyard - Payoff"]
+tags = ["Land Graveyard - Payoff","Tier 3"]
 
 ["Illusionist's Stratagem"]
 mana_cost = ["3","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["ETB - Payoff","Spells - Enabler"]
+tags = ["ETB - Payoff","Spells - Enabler","Tier 2","Spice"]
 
 ["Incendiary Flow"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["sorcery"]
-tags = ["Removal","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Spells - Enabler","Removal - Size","Tier 2"]
+
+["Incubation Druid"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tier 1","Counters - Payoff","Flash - Threat","Keyword","Ramp - Enabler"]
 
 ["Indulgent Aristocrat"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Payoff","Lifegain - Enabler","Counters - Enabler","Vampires - Enabler","Vampires - Payoff"]
+tags = ["Sacrifice - Payoff","Lifegain - Enabler","Counters - Enabler","Vampires - Enabler","Vampires - Payoff","Tier 3"]
 
 ["Inspiring Cleric"]
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Enabler"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Enabler","Tier 3"]
 
 ["Isareth the Awakener"]
 mana_cost = ["1","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Graveyard - Payoff"]
+tags = ["Graveyard - Payoff","Tier 2"]
 
 ["Isolated Chapel"]
 mana_cost = []
@@ -914,55 +902,67 @@ tags = []
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Spells - Payoff","Graveyard - Payoff","Signpost","Higher Toughness","Wizards - Enabler"]
+tags = ["Spells - Payoff","Graveyard - Payoff","Signpost","Higher Toughness","Wizards - Enabler","Tier 2","Spice"]
 
 ["Izzet Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
+
+["Jace's Archivist"]
+mana_cost = ["1","U","U"]
+color_identity = "U"
+types = ["creature"]
+tags = ["Tier 2","Spice","Wizards - Enabler","Madness/Hellbent - Enabler","Madness/Hellbent - Payoff"]
 
 ["Jeskai Ascendancy"]
 mana_cost = ["U","R","W"]
 color_identity = "RUW"
 types = ["enchantment"]
-tags = ["Signpost","Spells - Payoff","Tokens - Payoff","Madness/Hellbent - Enabler"]
+tags = ["Signpost","Spells - Payoff","Tokens - Payoff","Madness/Hellbent - Enabler","Tier 2","Spice"]
 
 ["Jori En, Ruin Diver"]
 mana_cost = ["1","U","R"]
 color_identity = "UR"
 types = ["creature"]
-tags = ["Higher Toughness","Wizards - Enabler","Card Draw"]
+tags = ["Higher Toughness","Wizards - Enabler","Card Draw","Tier 2","Spice"]
 
-["Juniper Order Ranger"]
-mana_cost = ["3","G","W"]
-color_identity = "GW"
+["Judith, the Scourge Diva"]
+mana_cost = ["1","B","R"]
+color_identity = "BR"
 types = ["creature"]
-tags = ["Counters - Enabler","Tokens - Payoff","ETB - Enabler","Higher Toughness"]
+tags = ["Sacrifice - Payoff","Signpost","Tier 1","Spice"]
 
 ["Kalastria Highborn"]
 mana_cost = ["B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Vampires - Enabler","Vampires - Payoff"]
+tags = ["Lifegain - Enabler","Vampires - Enabler","Vampires - Payoff","Tier 2"]
 
 ["Kami of Ancient Law"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Spirits - Enabler"]
+tags = ["Spirits - Enabler","Tier 3","Noncreature Permanent Interaction"]
+
+["Kari Zev's Expertise"]
+mana_cost = ["1","R","R"]
+color_identity = "R"
+types = ["sorcery"]
+tags = ["Spells - Enabler","Sacrifice - Enabler","Tier 3"]
 
 ["Kari Zev, Skyship Raider"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Tokens - Enabler","Higher Toughness"]
+tags = ["Sacrifice - Enabler","Tokens - Enabler","Higher Toughness","Tier 1"]
 
 ["Karn, Silver Golem"]
 mana_cost = ["5"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Signpost","Higher Toughness","Artifacts - Enabler","Artifacts (Noncreature) - Payoff","Artifacts (Creature) - Enabler"]
+tags = ["Signpost","Higher Toughness","Artifacts - Enabler","Artifacts (Noncreature) - Payoff","Artifacts (Creature) - Enabler","Tier 3"]
 
 ["Karplusan Forest"]
 mana_cost = []
@@ -974,73 +974,55 @@ tags = []
 mana_cost = ["4","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Signpost","Higher Toughness","Big"]
+tags = ["Graveyard - Payoff","Signpost","Higher Toughness","Big","Tier 2"]
 
 ["Key to the City"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Madness/Hellbent - Enabler","Artifacts - Enabler","Ninjutsu - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Madness/Hellbent - Enabler","Artifacts - Enabler","Ninjutsu - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2"]
 
 ["Killing Glare"]
 mana_cost = ["X","B"]
 color_identity = "B"
 types = ["instant"]
-tags = ["Removal","Removal - Size"]
+tags = ["Removal","Removal - Size","Tier 3"]
 
 ["Kindly Stranger"]
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Removal","Higher Toughness","Keyword","Madness/Hellbent - Payoff","Removal - Size"]
+tags = ["Graveyard - Payoff","Removal","Higher Toughness","Keyword","Madness/Hellbent - Payoff","Removal - Size","Tier 2"]
 
 ["Kiri-Onna"]
 mana_cost = ["4","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Spirits - Enabler","ETB - Enabler","Bounce"]
+tags = ["Spirits - Enabler","ETB - Enabler","Bounce","Tier 4"]
 
 ["Kitesail Freebooter"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Ninjutsu - Enabler"]
-
-["Knotvine Paladin"]
-mana_cost = ["G","W"]
-color_identity = "GW"
-types = ["creature"]
-tags = ["Tokens - Payoff"]
+tags = ["Ninjutsu - Enabler","Tier 2","Noncreature Permanent Interaction"]
 
 ["Lantern Kami"]
 mana_cost = ["W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Spirits - Enabler","Ninjutsu - Enabler"]
-
-["Launch the Fleet"]
-mana_cost = ["W"]
-color_identity = "W"
-types = ["sorcery"]
-tags = ["Tokens - Enabler","Tokens - Payoff","Keyword","Spells - Enabler","Heroic - Enabler"]
+tags = ["Spirits - Enabler","Ninjutsu - Enabler","Tier 4"]
 
 ["Lightning Helix"]
 mana_cost = ["R","W"]
 color_identity = "RW"
 types = ["instant"]
-tags = ["Removal","Lifegain - Enabler","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Lifegain - Enabler","Spells - Enabler","Removal - Size","Tier 1"]
 
 ["Liliana's Specter"]
 mana_cost = ["1","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["ETB - Enabler","Ninjutsu - Enabler"]
-
-["Llanowar Elves"]
-mana_cost = ["G"]
-color_identity = "G"
-types = ["creature"]
-tags = []
+tags = ["ETB - Enabler","Ninjutsu - Enabler","Tier 3"]
 
 ["Llanowar Wastes"]
 mana_cost = []
@@ -1052,85 +1034,85 @@ tags = []
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Lifegain - Payoff","Lifegain - Enabler","Keyword"]
-
-["Loyal Pegasus"]
-mana_cost = ["W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Ninjutsu - Enabler"]
+tags = ["Lifegain - Payoff","Lifegain - Enabler","Keyword","Tier 3"]
 
 ["Ludevic's Test Subject"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Big","Flash - Threat"]
+tags = ["Big","Flash - Threat","Tier 2"]
+
+["Lupine Prototype"]
+mana_cost = ["2"]
+color_identity = "C"
+types = ["artifact","creature"]
+tags = ["Tier 3","Madness/Hellbent - Payoff","Artifacts (Cheap) - Enabler","Artifacts (Creature) - Enabler","Artifacts - Enabler"]
 
 ["Magma Burst"]
 mana_cost = ["3","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Keyword","Land Graveyard - Enabler","Removal","Spells - Enabler","Removal - Size"]
+tags = ["Keyword","Land Graveyard - Enabler","Removal","Spells - Enabler","Removal - Size","Tier 3"]
 
 ["Magmatic Force"]
 mana_cost = ["5","R","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Big","Reanimator - Payoff"]
+tags = ["Big","Reanimator - Payoff","Tier 3","Ramp - Payoff"]
 
 ["Magmatic Insight"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["sorcery"]
-tags = ["Land Graveyard - Enabler","Spells - Enabler"]
+tags = ["Land Graveyard - Enabler","Spells - Enabler","Tier 2"]
 
 ["Magmaw"]
 mana_cost = ["3","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Sacrifice - Payoff","Signpost"]
+tags = ["Sacrifice - Payoff","Signpost","Tier 3"]
 
 ["Magus of the Scroll"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Removal","Wizards - Enabler","Madness/Hellbent - Payoff","Removal - Size"]
+tags = ["Removal","Wizards - Enabler","Madness/Hellbent - Payoff","Removal - Size","Tier 3"]
 
 ["Magus of the Wheel"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Graveyard - Enabler","Wizards - Enabler","Madness/Hellbent - Enabler"]
+tags = ["Graveyard - Enabler","Wizards - Enabler","Madness/Hellbent - Enabler","Tier 2"]
 
 ["Mana Leak"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Flash - Counterspell","Spells - Enabler"]
+tags = ["Spells - Enabler","Flash - Interaction","Tier 2","Noncreature Permanent Interaction"]
 
 ["Martial Glory"]
 mana_cost = ["W","R"]
 color_identity = "RW"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler","Spells - Enabler"]
+tags = ["Trick","Heroic - Enabler","Spells - Enabler","Tier 2"]
 
 ["Martyr of Dusk"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Lifegain - Enabler","Vampires - Enabler"]
+tags = ["Sacrifice - Enabler","Lifegain - Enabler","Vampires - Enabler","Tier 3"]
 
 ["Maverick Thopterist"]
 mana_cost = ["3","U","R"]
 color_identity = "UR"
 types = ["creature"]
-tags = ["Signpost","Tokens - Enabler","Artifacts - Enabler","Keyword","ETB - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Signpost","Tokens - Enabler","Artifacts - Enabler","Keyword","ETB - Enabler","Artifacts (Creature) - Enabler","Tier 2"]
 
 ["Mavren Fein, Dusk Apostle"]
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Tokens - Enabler","Lifegain - Enabler","Signpost","Vampires - Enabler","Vampires - Payoff"]
+tags = ["Tokens - Enabler","Lifegain - Enabler","Signpost","Vampires - Enabler","Vampires - Payoff","Tier 3"]
 
 ["Meandering River"]
 mana_cost = []
@@ -1138,455 +1120,443 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
+["Memorial to Glory"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = ["Land Graveyard - Enabler","Tokens - Enabler","Tier 3"]
+
 ["Memorial to Unity"]
 mana_cost = []
 color_identity = "G"
 types = ["land"]
-tags = ["Land Graveyard - Enabler"]
+tags = ["Land Graveyard - Enabler","Tier 3"]
 
 ["Metallic Mimic"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Counters - Enabler","Tokens - Payoff","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Counters - Enabler","Tokens - Payoff","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2"]
 
 ["Metalwork Colossus"]
 mana_cost = ["11"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Signpost","Big","Artifacts - Enabler","Artifacts (Noncreature) - Payoff","Artifacts (Creature) - Enabler"]
-
-["Midnight Oil"]
-mana_cost = ["2","B","B"]
-color_identity = "B"
-types = ["enchantment"]
-tags = ["Card Draw"]
+tags = ["Signpost","Big","Artifacts - Enabler","Artifacts (Noncreature) - Payoff","Artifacts (Creature) - Enabler","Tier 3"]
 
 ["Might of the Masses"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["instant"]
-tags = ["Trick","Tokens - Payoff","Heroic - Enabler"]
+tags = ["Trick","Tokens - Payoff","Heroic - Enabler","Tier 3"]
 
 ["Mikaeus, the Lunarch"]
 mana_cost = ["X","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Enabler","Tokens - Payoff","Signpost","Big"]
+tags = ["Counters - Enabler","Tokens - Payoff","Signpost","Big","Tier 1"]
 
 ["Militia Bugler"]
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Higher Toughness","ETB - Enabler"]
+tags = ["Higher Toughness","ETB - Enabler","Tier 2"]
 
 ["Mina and Denn, Wildborn"]
 mana_cost = ["2","R","G"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Landfall - Enabler","Big"]
+tags = ["Landfall - Enabler","Big","Tier 2"]
 
 ["Mindless Automaton"]
 mana_cost = ["4"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Counters - Enabler","Counters - Payoff","Madness/Hellbent - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Counters - Enabler","Counters - Payoff","Madness/Hellbent - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Tier 2"]
 
 ["Mindstorm Crown"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Card Draw","Madness/Hellbent - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Card Draw","Madness/Hellbent - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
+
+["Ministrant of Obligation"]
+mana_cost = ["2","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Tier 2","Tokens - Enabler","Sacrifice - Enabler","Keyword"]
 
 ["Mirror Mockery"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Removal","ETB - Payoff"]
+tags = ["Removal","ETB - Payoff","Tier 3"]
 
 ["Mistblade Shinobi"]
 mana_cost = ["2","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Ninjutsu - Payoff"]
+tags = ["Ninjutsu - Payoff","Tier 2"]
 
 ["Molten Vortex"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["enchantment"]
-tags = ["Land Graveyard - Enabler","Removal","Removal - Size"]
+tags = ["Land Graveyard - Enabler","Removal","Removal - Size","Tier 2"]
+
+["Mother Bear"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Tokens - Enabler","Tier 3"]
 
 ["Murderous Cut"]
 mana_cost = ["4","B"]
 color_identity = "B"
 types = ["instant"]
-tags = ["Removal","Graveyard - Payoff","Keyword"]
+tags = ["Removal","Graveyard - Payoff","Keyword","Tier 2"]
 
 ["Mystic Snake"]
 mana_cost = ["1","G","U","U"]
 color_identity = "GU"
 types = ["creature"]
-tags = ["Signpost","Flash - Counterspell"]
+tags = ["Signpost","Flash - Interaction","Tier 2","Noncreature Permanent Interaction"]
 
 ["Naru Meha, Master Wizard"]
 mana_cost = ["2","U","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Signpost","Wizards - Payoff","Spells - Payoff","Wizards - Enabler","Flash - Threat"]
-
-["Nearheath Chaplain"]
-mana_cost = ["3","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Lifegain - Enabler","Tokens - Enabler","Spirits - Enabler"]
+tags = ["Signpost","Wizards - Payoff","Spells - Payoff","Wizards - Enabler","Flash - Threat","Tier 2","Spice"]
 
 ["Nebelgast Herald"]
 mana_cost = ["2","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Spirits - Payoff","Spirits - Enabler","Flash - Threat","Ninjutsu - Enabler"]
+tags = ["Spirits - Payoff","Spirits - Enabler","Flash - Threat","Ninjutsu - Enabler","Tier 3"]
 
 ["Necropolis Fiend"]
 mana_cost = ["7","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Signpost","Graveyard - Payoff","Higher Toughness","Big","Keyword"]
+tags = ["Signpost","Graveyard - Payoff","Higher Toughness","Big","Keyword","Tier 2"]
 
 ["Necrotic Wound"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["instant"]
-tags = ["Graveyard - Payoff"]
+tags = ["Graveyard - Payoff","Tier 2"]
 
 ["Negate"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Flash - Counterspell","Spells - Enabler"]
+tags = ["Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent Interaction"]
 
 ["Neheb, the Eternal"]
 mana_cost = ["3","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Higher Toughness","Big","Keyword"]
+tags = ["Higher Toughness","Big","Keyword","Tier 2","Ramp - Enabler"]
 
 ["Niblis of the Urn"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Spirits - Enabler","Ninjutsu - Enabler"]
+tags = ["Spirits - Enabler","Ninjutsu - Enabler","Tier 4","cuttable"]
+
+["Nightmare's Thirst"]
+mana_cost = ["B"]
+color_identity = "B"
+types = ["instant"]
+tags = ["Removal","Removal - Size","Lifegain - Enabler","Lifegain - Payoff","Tier 3"]
 
 ["Ninja of the Deep Hours"]
 mana_cost = ["3","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Ninjutsu - Payoff"]
+tags = ["Ninjutsu - Payoff","Tier 2"]
 
 ["Nyx Weaver"]
 mana_cost = ["1","B","G"]
 color_identity = "BG"
 types = ["enchantment","creature"]
-tags = ["Graveyard - Enabler","Graveyard - Payoff","Signpost","Higher Toughness"]
+tags = ["Graveyard - Enabler","Graveyard - Payoff","Signpost","Higher Toughness","Tier 2"]
 
 ["Oathsworn Vampire"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Lifegain - Payoff","Vampires - Enabler"]
-
-["Ochran Assassin"]
-mana_cost = ["1","B","G"]
-color_identity = "BG"
-types = ["creature"]
-tags = ["Removal"]
-
-["Ogre Battledriver"]
-mana_cost = ["2","R","R"]
-color_identity = "R"
-types = ["creature"]
-tags = ["Signpost","Tokens - Payoff"]
+tags = ["Lifegain - Payoff","Vampires - Enabler","Tier 3"]
 
 ["Okiba-Gang Shinobi"]
 mana_cost = ["3","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Ninjutsu - Payoff"]
+tags = ["Ninjutsu - Payoff","Tier 3"]
 
 ["Omnath, Locus of Rage"]
 mana_cost = ["3","R","R","G","G"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Landfall - Payoff","Keyword"]
-
-["One Dozen Eyes"]
-mana_cost = ["5","G"]
-color_identity = "G"
-types = ["sorcery"]
-tags = ["Tokens - Enabler"]
+tags = ["Reanimator - Payoff","Big","Landfall - Payoff","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Oppressive Rays"]
 mana_cost = ["W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Removal"]
+tags = ["Removal","Tier 3"]
 
 ["Opt"]
 mana_cost = ["U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Spells - Enabler"]
+tags = ["Spells - Enabler","Tier 2"]
 
 ["Oracle of Mul Daya"]
 mana_cost = ["3","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Landfall - Enabler"]
+tags = ["Landfall - Enabler","Tier 1","Spice","Ramp - Enabler"]
 
 ["Ordeal of Heliod"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Lifegain - Enabler","Counters - Enabler"]
+tags = ["Heroic - Enabler","Lifegain - Enabler","Counters - Enabler","Tier 3"]
 
 ["Ordeal of Thassa"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw"]
+tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw","Tier 2"]
 
 ["Orzhov Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Outnumber"]
 mana_cost = ["R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Removal","Tokens - Payoff","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Tokens - Payoff","Spells - Enabler","Removal - Size","Tier 2"]
 
 ["Pacification Array"]
 mana_cost = ["1"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Removal","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Removal","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 4"]
 
 ["Pacifism"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Removal"]
+tags = ["Removal","Tier 3"]
 
 ["Pack Guardian"]
 mana_cost = ["2","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Land Graveyard - Enabler","Spirits - Enabler","Flash - Threat"]
+tags = ["Land Graveyard - Enabler","Spirits - Enabler","Flash - Threat","Tier 2"]
 
 ["Palladium Myr"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2","Ramp - Enabler"]
 
 ["Panharmonicon"]
 mana_cost = ["4"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Signpost","ETB - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Signpost","ETB - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Tier 3","Spice"]
 
 ["Path of Bravery"]
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Lifegain - Enabler","Lifegain - Payoff","Tokens - Payoff"]
+tags = ["Lifegain - Enabler","Lifegain - Payoff","Tokens - Payoff","Tier 2"]
 
 ["Path of Discovery"]
 mana_cost = ["3","G"]
 color_identity = "G"
 types = ["enchantment"]
-tags = ["Counters - Enabler","Graveyard - Enabler","Landfall - Enabler","Keyword","Tokens - Payoff"]
+tags = ["Counters - Enabler","Graveyard - Enabler","Landfall - Enabler","Keyword","Tokens - Payoff","Tier 2","Spice"]
 
 ["Peel from Reality"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["ETB - Payoff","Bounce","Spells - Enabler"]
+tags = ["ETB - Payoff","Bounce","Spells - Enabler","Tier 3"]
 
 ["Perilous Myr"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Removal","Sacrifice - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Removal - Size"]
+tags = ["Removal","Sacrifice - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Removal - Size","Tier 3"]
 
 ["Phalanx Leader"]
 mana_cost = ["W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Signpost","Heroic - Payoff","Counters - Enabler","Keyword"]
+tags = ["Signpost","Heroic - Payoff","Counters - Enabler","Keyword","Tier 2","Spice"]
 
 ["Phantom Nomad"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Enabler","Spirits - Enabler"]
+tags = ["Counters - Enabler","Spirits - Enabler","Tier 2"]
 
 ["Pianna, Nomad Captain"]
 mana_cost = ["1","W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Tokens - Payoff","Signpost"]
+tags = ["Tokens - Payoff","Signpost","Tier 2"]
 
 ["Pilfering Imp"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Ninjutsu - Enabler"]
+tags = ["Ninjutsu - Enabler","Tier 3","Noncreature Permanent Interaction"]
 
 ["Piston Sledge"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Keyword","Artifacts - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Keyword","Artifacts - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
 
-["Pongify"]
-mana_cost = ["U"]
+["Pore Over the Pages"]
+mana_cost = ["3","U","U"]
 color_identity = "U"
-types = ["instant"]
-tags = ["Removal","Trick","Flash - Threat","Spells - Enabler"]
+types = ["sorcery"]
+tags = ["Tier 2","Spells - Enabler","Card Draw","Madness/Hellbent - Enabler"]
 
 ["Possessed Skaab"]
 mana_cost = ["3","U","B"]
 color_identity = "BU"
 types = ["creature"]
-tags = ["ETB - Enabler"]
-
-["Precognition Field"]
-mana_cost = ["3","U"]
-color_identity = "U"
-types = ["enchantment"]
-tags = ["Spells - Payoff","Signpost","Card Draw"]
+tags = ["ETB - Enabler","Tier 2"]
 
 ["Presence of Gond"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["enchantment"]
-tags = ["Tokens - Enabler","Heroic - Enabler"]
+tags = ["Tokens - Enabler","Heroic - Enabler","Tier 4","cuttable"]
 
 ["Prey Upon"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["sorcery"]
-tags = ["Removal","Heroic - Enabler","Removal - Size"]
+tags = ["Removal","Heroic - Enabler","Removal - Size","Tier 2"]
 
 ["Prophet of Kruphix"]
 mana_cost = ["3","U","G"]
 color_identity = "GU"
 types = ["creature"]
-tags = ["Signpost","Higher Toughness","Wizards - Enabler","Flash - Threat"]
+tags = ["Signpost","Higher Toughness","Wizards - Enabler","Flash - Threat","Tier 1","Spice"]
 
 ["Prophetic Prism"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 4"]
 
 ["Pyrite Spellbomb"]
 mana_cost = ["1"]
 color_identity = "R"
 types = ["artifact"]
-tags = ["Removal","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Removal - Size"]
+tags = ["Removal","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Removal - Size","Tier 2"]
 
 ["Pyromancer's Goggles"]
 mana_cost = ["5"]
 color_identity = "R"
 types = ["artifact"]
-tags = ["Signpost","Spells - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Signpost","Spells - Payoff","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Tier 2","Spice"]
 
 ["Quickling"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["ETB - Payoff","Ninjutsu - Enabler","Flash - Threat"]
+tags = ["ETB - Payoff","Ninjutsu - Enabler","Flash - Threat","Tier 3"]
 
 ["Rakdos Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Ramunap Excavator"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Land Graveyard - Payoff","Landfall - Enabler","Higher Toughness"]
+tags = ["Graveyard - Payoff","Land Graveyard - Payoff","Landfall - Enabler","Higher Toughness","Tier 2"]
 
 ["Rattlechains"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Spirits - Payoff","Spirits - Enabler","Flash - Threat","Ninjutsu - Enabler"]
+tags = ["Spirits - Payoff","Spirits - Enabler","Flash - Threat","Ninjutsu - Enabler","Tier 2"]
 
 ["Ravenous Rats"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["ETB - Enabler"]
+tags = ["ETB - Enabler","Tier 3"]
 
 ["Reap What Is Sown"]
 mana_cost = ["1","W","G"]
 color_identity = "GW"
 types = ["instant"]
-tags = ["Counters - Enabler"]
+tags = ["Counters - Enabler","Tier 3"]
 
 ["Reassembling Skeleton"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Graveyard - Payoff"]
+tags = ["Sacrifice - Enabler","Graveyard - Payoff","Tier 2"]
 
 ["Reckless Racer"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Madness/Hellbent - Enabler","Higher Toughness"]
+tags = ["Madness/Hellbent - Enabler","Higher Toughness","Tier 2"]
 
 ["Renegade Krasis"]
 mana_cost = ["1","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","Counters - Payoff","Signpost","Keyword"]
+tags = ["Counters - Enabler","Counters - Payoff","Signpost","Keyword","Tier 3"]
 
 ["Rhox Faithmender"]
 mana_cost = ["3","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Signpost","Higher Toughness"]
+tags = ["Lifegain - Enabler","Signpost","Higher Toughness","Tier 3"]
 
 ["Riddleform"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Spells - Payoff"]
+tags = ["Spells - Payoff","Tier 3"]
 
 ["Rise from the Tides"]
 mana_cost = ["5","U"]
 color_identity = "U"
 types = ["sorcery"]
-tags = ["Graveyard - Payoff","Spells - Payoff","Signpost","Big","Spells - Enabler"]
+tags = ["Graveyard - Payoff","Spells - Payoff","Signpost","Big","Spells - Enabler","Tier 3","Spice"]
 
 ["Rishkar, Peema Renegade"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","ETB - Enabler"]
+tags = ["Counters - Enabler","ETB - Enabler","Tier 1","Ramp - Enabler"]
 
 ["River Hoopoe"]
 mana_cost = ["G","U"]
 color_identity = "GU"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Flash - Threat","Card Draw","Higher Toughness","Ninjutsu - Enabler"]
+tags = ["Lifegain - Enabler","Flash - Threat","Card Draw","Higher Toughness","Ninjutsu - Enabler","Tier 4"]
 
 ["Rootbound Crag"]
 mana_cost = []
@@ -1598,85 +1568,91 @@ tags = []
 mana_cost = ["2","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Graveyard - Enabler","ETB - Enabler","Card Draw","Madness/Hellbent - Enabler"]
+tags = ["Graveyard - Enabler","ETB - Enabler","Card Draw","Madness/Hellbent - Enabler","Tier 2"]
 
 ["Ruin Raider"]
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Keyword","Card Draw"]
+tags = ["Keyword","Card Draw","Tier 2"]
+
+["Runaway Steam-Kin"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Tier 2","Spice"]
 
 ["Sai, Master Thopterist"]
 mana_cost = ["2","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Artifacts - Payoff","Signpost","Higher Toughness"]
+tags = ["Artifacts - Payoff","Signpost","Higher Toughness","Tier 2"]
 
 ["Sanctum Seeker"]
 mana_cost = ["2","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Signpost","Higher Toughness","Vampires - Enabler","Vampires - Payoff"]
+tags = ["Lifegain - Enabler","Signpost","Higher Toughness","Vampires - Enabler","Vampires - Payoff","Tier 3"]
 
 ["Saproling Migration"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["sorcery"]
-tags = ["Tokens - Enabler"]
+tags = ["Tokens - Enabler","Tier 2"]
+
+["Satyr Hoplite"]
+mana_cost = ["R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Tier 4","Heroic - Payoff"]
 
 ["Satyr Wayfinder"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Enabler","ETB - Enabler"]
+tags = ["Graveyard - Enabler","ETB - Enabler","Tier 2"]
 
 ["Scourge Wolf"]
 mana_cost = ["R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Keyword","Madness/Hellbent - Payoff"]
+tags = ["Keyword","Madness/Hellbent - Payoff","Tier 2"]
 
 ["Scourge of Nel Toth"]
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Signpost","Big"]
+tags = ["Reanimator - Payoff","Signpost","Big","Tier 2","Spice"]
 
 ["Scrounging Bandar"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler"]
+tags = ["Counters - Enabler","Tier 3"]
 
 ["Scute Mob"]
 mana_cost = ["G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Flash - Threat","Big"]
+tags = ["Flash - Threat","Big","Tier 2"]
 
 ["Seal Away"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Removal"]
-
-["Second Harvest"]
-mana_cost = ["2","G","G"]
-color_identity = "G"
-types = ["instant"]
-tags = ["Tokens - Payoff","Signpost"]
+tags = ["Removal","Tier 3"]
 
 ["Selesnya Evangel"]
 mana_cost = ["G","W"]
 color_identity = "GW"
 types = ["creature"]
-tags = ["Tokens - Enabler","Higher Toughness"]
+tags = ["Tokens - Enabler","Higher Toughness","Tier 2"]
 
 ["Selesnya Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Shivan Reef"]
 mana_cost = []
@@ -1684,137 +1660,131 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
-["Sickening Dreams"]
-mana_cost = ["1","B"]
-color_identity = "B"
-types = ["sorcery"]
-tags = ["Madness/Hellbent - Enabler"]
+["Sidisi, Brood Tyrant"]
+mana_cost = ["1","B","G","U"]
+color_identity = "BGU"
+types = ["creature"]
+tags = ["Signpost","Graveyard - Enabler","Graveyard - Payoff","Tier 1"]
 
 ["Sifter Wurm"]
 mana_cost = ["5","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Big","ETB - Enabler"]
-
-["Signal Pest"]
-mana_cost = ["1"]
-color_identity = "C"
-types = ["artifact","creature"]
-tags = ["Ninjutsu - Enabler","Artifacts - Enabler","Tokens - Payoff","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Big","ETB - Enabler","Tier 3","Ramp - Payoff"]
 
 ["Simic Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Sin Prodder"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Graveyard - Enabler"]
+tags = ["Graveyard - Enabler","Tier 2"]
 
 ["Sinister Concoction"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["enchantment"]
-tags = ["Removal","Madness/Hellbent - Enabler"]
+tags = ["Removal","Madness/Hellbent - Enabler","Tier 3"]
 
 ["Siren Stormtamer"]
 mana_cost = ["U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Wizards - Enabler","Ninjutsu - Enabler"]
+tags = ["Wizards - Enabler","Ninjutsu - Enabler","Tier 3"]
 
 ["Skarrg Guildmage"]
 mana_cost = ["R","G"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Land Graveyard - Enabler"]
+tags = ["Land Graveyard - Enabler","Tier 2"]
 
 ["Skilled Animator"]
 mana_cost = ["2","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Higher Toughness","Big","Artifacts (Cheap) - Payoff"]
+tags = ["Higher Toughness","Big","Artifacts (Cheap) - Payoff","Tier 3"]
 
 ["Skinshifter"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Big","Flash - Threat","Ninjutsu - Enabler"]
+tags = ["Big","Flash - Threat","Ninjutsu - Enabler","Tier 2"]
 
 ["Skullmulcher"]
 mana_cost = ["4","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tokens - Payoff","Counters - Enabler","Keyword","ETB - Enabler","Sacrifice - Payoff","Card Draw"]
-
-["Skymarcher Aspirant"]
-mana_cost = ["W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Keyword","Vampires - Enabler"]
+tags = ["Tokens - Payoff","Counters - Enabler","Keyword","ETB - Enabler","Sacrifice - Payoff","Card Draw","Tier 1","Spice"]
 
 ["Skyscanner"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Ninjutsu - Enabler","ETB - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Ninjutsu - Enabler","ETB - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
 
-["Smother"]
-mana_cost = ["1","B"]
-color_identity = "B"
-types = ["instant"]
-tags = ["Removal"]
+["Smoke Shroud"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Ninjutsu - Enabler","Tier 3"]
 
 ["Soul's Fire"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Spells - Enabler","Heroic - Enabler","Removal","Removal - Size"]
+tags = ["Spells - Enabler","Heroic - Enabler","Removal","Removal - Size","Tier 3"]
 
 ["Soulfire Grand Master"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Signpost","Lifegain - Enabler","Spells - Payoff"]
+tags = ["Signpost","Lifegain - Enabler","Spells - Payoff","Tier 1","Spice"]
 
-["Spawnbroker"]
-mana_cost = ["2","U"]
-color_identity = "U"
-types = ["creature"]
-tags = ["ETB - Enabler","Wizards - Enabler"]
-
-["Spectral Shepherd"]
-mana_cost = ["2","W"]
+["Soulherder"]
+mana_cost = ["1","W","U"]
 color_identity = "UW"
 types = ["creature"]
-tags = ["Spirits - Enabler","Spirits - Payoff","Ninjutsu - Enabler"]
+tags = ["Spirits - Enabler","ETB - Payoff","Signpost","Tier 2"]
+
+["Spellgorger Weird"]
+mana_cost = ["2","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Tier 3","Spells - Payoff","Artifacts (Noncreature) - Payoff"]
 
 ["Spore Swarm"]
 mana_cost = ["3","G"]
 color_identity = "G"
 types = ["instant"]
-tags = ["Tokens - Enabler","Flash - Threat"]
+tags = ["Tokens - Enabler","Flash - Threat","Tier 3"]
+
+["Squirrel Wrangler"]
+mana_cost = ["2","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","Land Graveyard - Enabler","Tier 3"]
 
 ["Steel Overseer"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Signpost","Counters - Enabler","Artifacts - Enabler","Artifacts (Creature) - Payoff","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Signpost","Counters - Enabler","Artifacts - Enabler","Artifacts (Creature) - Payoff","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 1"]
 
 ["Steward of Solidarity"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Tokens - Enabler","Keyword"]
+tags = ["Tokens - Enabler","Keyword","Tier 2"]
 
 ["Stitcher's Supplier"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Graveyard - Enabler"]
+tags = ["Graveyard - Enabler","Tier 3"]
 
 ["Stone Quarry"]
 mana_cost = []
@@ -1826,13 +1796,13 @@ tags = []
 mana_cost = ["U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Trick","Wizards - Payoff","Spells - Enabler"]
+tags = ["Trick","Wizards - Payoff","Spells - Enabler","Tier 3"]
 
 ["Stromkirk Condemned"]
 mana_cost = ["B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Vampires - Enabler","Vampires - Payoff","Madness/Hellbent - Enabler"]
+tags = ["Vampires - Enabler","Vampires - Payoff","Madness/Hellbent - Enabler","Tier 3"]
 
 ["Submerged Boneyard"]
 mana_cost = []
@@ -1862,37 +1832,31 @@ tags = []
 mana_cost = ["B"]
 color_identity = "B"
 types = ["instant"]
-tags = ["Trick","ETB - Payoff"]
+tags = ["Trick","ETB - Payoff","Tier 2"]
 
 ["Supreme Phantom"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Signpost","Spirits - Enabler","Spirits - Payoff","Higher Toughness","Ninjutsu - Enabler"]
+tags = ["Signpost","Spirits - Enabler","Spirits - Payoff","Higher Toughness","Ninjutsu - Enabler","Tier 2"]
 
 ["Supreme Will"]
 mana_cost = ["2","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Flash - Counterspell","Spells - Enabler"]
+tags = ["Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent Interaction"]
 
 ["Swift Justice"]
 mana_cost = ["W"]
 color_identity = "W"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler"]
+tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler","Tier 2"]
 
 ["Tallowisp"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Spirits - Payoff","Keyword","Spirits - Enabler","Higher Toughness"]
-
-["Tapestry of the Ages"]
-mana_cost = ["4"]
-color_identity = "C"
-types = ["artifact"]
-tags = ["Artifacts (Noncreature) - Enabler","Artifacts - Enabler"]
+tags = ["Spirits - Payoff","Keyword","Spirits - Enabler","Higher Toughness","Tier 2","Spice"]
 
 ["Temple of Abandon"]
 mana_cost = []
@@ -1958,73 +1922,79 @@ tags = []
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler","Keyword","Spells - Enabler"]
+tags = ["Trick","Heroic - Enabler","Keyword","Spells - Enabler","Tier 3"]
+
+["Tendershoot Dryad"]
+mana_cost = ["4","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","Tokens - Payoff","Signpost","Tier 3","Keyword"]
+
+["Tenth District Legionnaire"]
+mana_cost = ["R","W"]
+color_identity = "RW"
+types = ["creature"]
+tags = ["Signpost","Tier 2","Heroic - Payoff"]
 
 ["Territorial Allosaurus"]
 mana_cost = ["2","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Big","Keyword"]
+tags = ["Big","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Teysa, Orzhov Scion"]
 mana_cost = ["1","W","B"]
 color_identity = "BW"
 types = ["creature"]
-tags = ["Signpost","Sacrifice - Payoff","Tokens - Payoff","Higher Toughness"]
+tags = ["Signpost","Sacrifice - Payoff","Tokens - Payoff","Higher Toughness","Tier 2","Spice"]
 
 ["The Flame of Keld"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["enchantment"]
-tags = ["Keyword","Madness/Hellbent - Enabler","Madness/Hellbent - Payoff"]
+tags = ["Keyword","Madness/Hellbent - Enabler","Madness/Hellbent - Payoff","Tier 3","Spice"]
 
 ["The Gitrog Monster"]
 mana_cost = ["3","B","G"]
 color_identity = "BG"
 types = ["creature"]
-tags = ["Signpost","Graveyard - Payoff","Big","Land Graveyard - Enabler","Land Graveyard - Payoff"]
+tags = ["Signpost","Graveyard - Payoff","Big","Land Graveyard - Enabler","Land Graveyard - Payoff","Tier 2","Spice"]
 
 ["Thing in the Ice"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword"]
-
-["Thirst for Knowledge"]
-mana_cost = ["2","U"]
-color_identity = "U"
-types = ["instant"]
-tags = ["Artifacts - Payoff","Card Draw","Spells - Enabler","Madness/Hellbent - Enabler"]
+tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword","Tier 1","Spice"]
 
 ["Thopter Squadron"]
 mana_cost = ["5"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Tokens - Enabler","Counters - Enabler","Counters - Payoff","Artifacts - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Tokens - Enabler","Counters - Enabler","Counters - Payoff","Artifacts - Enabler","Artifacts (Creature) - Enabler","Tier 2"]
 
 ["Thought Courier"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Wizards - Enabler","Madness/Hellbent - Enabler"]
-
-["Thresher Lizard"]
-mana_cost = ["2","R"]
-color_identity = "R"
-types = ["creature"]
-tags = ["Madness/Hellbent - Payoff"]
+tags = ["Wizards - Enabler","Madness/Hellbent - Enabler","Tier 2"]
 
 ["Throat Slitter"]
 mana_cost = ["4","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Ninjutsu - Payoff","Removal"]
+tags = ["Ninjutsu - Payoff","Removal","Tier 2"]
+
+["Throatseeker"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff","Tier 3","Vampires - Enabler"]
 
 ["Tilling Treefolk"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Land Graveyard - Payoff","Graveyard - Payoff","Landfall - Enabler","Higher Toughness"]
+tags = ["Land Graveyard - Payoff","Graveyard - Payoff","Landfall - Enabler","Higher Toughness","Tier 3"]
 
 ["Timber Gorge"]
 mana_cost = []
@@ -2036,25 +2006,31 @@ tags = []
 mana_cost = ["R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler","Spells - Enabler"]
+tags = ["Trick","Heroic - Enabler","Spells - Enabler","Tier 3"]
 
 ["Titania, Protector of Argoth"]
 mana_cost = ["3","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Land Graveyard - Payoff","Signpost"]
+tags = ["Land Graveyard - Payoff","Signpost","Tier 2","Spice"]
+
+["Together Forever"]
+mana_cost = ["W","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Spice","Tier 1","Counters - Enabler","Counters - Payoff","Keyword"]
 
 ["Tower Geist"]
 mana_cost = ["3","U"]
 color_identity = "U"
 types = ["creature"]
-tags = ["Spirits - Enabler","ETB - Enabler","Ninjutsu - Enabler"]
+tags = ["Spirits - Enabler","ETB - Enabler","Ninjutsu - Enabler","Tier 3"]
 
 ["Tragic Slip"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["instant"]
-tags = ["Removal"]
+tags = ["Removal","Tier 2"]
 
 ["Tranquil Expanse"]
 mana_cost = []
@@ -2066,37 +2042,25 @@ tags = []
 mana_cost = ["4"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Sacrifice - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Sacrifice - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Tier 3"]
 
 ["Tuktuk the Explorer"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Big","Sacrifice - Enabler"]
+tags = ["Big","Sacrifice - Enabler","Tier 3"]
 
 ["Tuskguard Captain"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword"]
-
-["Twinstrike"]
-mana_cost = ["3","B","R"]
-color_identity = "BR"
-types = ["instant"]
-tags = ["Removal","Madness/Hellbent - Payoff","Removal - Size"]
-
-["Tymaret, the Murder King"]
-mana_cost = ["B","R"]
-color_identity = "BR"
-types = ["creature"]
-tags = ["Signpost","Sacrifice - Payoff"]
+tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword","Tier 3"]
 
 ["Ultimate Price"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["instant"]
-tags = ["Removal"]
+tags = ["Removal","Tier 2"]
 
 ["Underground River"]
 mana_cost = []
@@ -2104,119 +2068,107 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
-["Urbis Protector"]
-mana_cost = ["4","W","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["ETB - Enabler"]
-
 ["Urge to Feed"]
 mana_cost = ["B","B"]
 color_identity = "B"
 types = ["instant"]
-tags = ["Vampires - Payoff","Removal","Removal - Size"]
+tags = ["Vampires - Payoff","Removal","Removal - Size","Tier 2"]
 
 ["Valorous Stance"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["instant"]
-tags = ["Removal","Trick","Heroic - Enabler","Spells - Enabler","Removal - Size"]
+tags = ["Removal","Trick","Heroic - Enabler","Spells - Enabler","Removal - Size","Tier 3"]
 
 ["Vampire Nighthawk"]
 mana_cost = ["1","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Higher Toughness","Vampires - Enabler","Ninjutsu - Enabler"]
+tags = ["Lifegain - Enabler","Higher Toughness","Vampires - Enabler","Ninjutsu - Enabler","Tier 2"]
 
 ["Vampiric Rites"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["enchantment"]
-tags = ["Lifegain - Enabler","Sacrifice - Payoff","Card Draw"]
+tags = ["Lifegain - Enabler","Sacrifice - Payoff","Card Draw","Tier 2"]
+
+["Venerated Loxodon"]
+mana_cost = ["4","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Tier 1","Counters - Enabler","Tokens - Payoff"]
 
 ["Vengeful Rebel"]
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Removal","Sacrifice - Payoff","Keyword","ETB - Enabler","Removal - Size"]
-
-["Verdant Embrace"]
-mana_cost = ["3","G","G"]
-color_identity = "G"
-types = ["enchantment"]
-tags = ["Tokens - Enabler","Heroic - Enabler","Big"]
+tags = ["Removal","Sacrifice - Payoff","Keyword","ETB - Enabler","Removal - Size","Tier 2"]
 
 ["Victimize"]
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["sorcery"]
-tags = ["Graveyard - Payoff","Reanimator - Enabler","Signpost"]
+tags = ["Graveyard - Payoff","Reanimator - Enabler","Signpost","Tier 2","Spice"]
 
 ["Viridian Zealot"]
 mana_cost = ["G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = []
-
-["Viscera Seer"]
-mana_cost = ["B"]
-color_identity = "B"
-types = ["creature"]
-tags = ["Vampires - Enabler","Wizards - Enabler","Sacrifice - Payoff"]
-
-["Vizier of Deferment"]
-mana_cost = ["2","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["ETB - Payoff","Flash - Threat"]
+tags = ["Tier 4","Noncreature Permanent Interaction"]
 
 ["Vizkopa Guildmage"]
 mana_cost = ["W","B"]
 color_identity = "BW"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Lifegain - Payoff","Wizards - Enabler"]
+tags = ["Lifegain - Enabler","Lifegain - Payoff","Wizards - Enabler","Tier 2"]
+
+["Voldaren Pariah"]
+mana_cost = ["3","B","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Signpost","Vampires - Enabler","Tier 1","Spice","Madness/Hellbent - Payoff","Sacrifice - Payoff","Keyword"]
 
 ["Voyage's End"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Bounce","Spells - Enabler"]
+tags = ["Bounce","Spells - Enabler","Flash - Interaction","Tier 3"]
 
 ["Wall of Omens"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Higher Toughness","ETB - Enabler"]
+tags = ["Higher Toughness","ETB - Enabler","Tier 1"]
 
 ["Weatherlight"]
 mana_cost = ["4"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Signpost","Artifacts - Payoff","Keyword","Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Signpost","Artifacts - Payoff","Keyword","Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Creature) - Enabler","Tier 1","Spice"]
 
 ["Weight of Conscience"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Removal"]
+tags = ["Removal","Tier 3"]
 
 ["Whisper, Blood Liturgist"]
 mana_cost = ["3","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Payoff","Reanimator - Enabler","Signpost","ETB - Payoff"]
+tags = ["Sacrifice - Payoff","Reanimator - Enabler","Signpost","ETB - Payoff","Tier 2","Spice"]
 
 ["Wizard's Lightning"]
 mana_cost = ["2","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Wizards - Payoff","Removal","Spells - Enabler","Removal - Size"]
+tags = ["Wizards - Payoff","Removal","Spells - Enabler","Removal - Size","Tier 2"]
 
 ["Wizard's Retort"]
 mana_cost = ["1","U","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Wizards - Payoff","Flash - Counterspell","Spells - Enabler"]
+tags = ["Wizards - Payoff","Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent Interaction"]
 
 ["Woodland Cemetery"]
 mana_cost = []
@@ -2230,12 +2182,6 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
-["World Shaper"]
-mana_cost = ["3","G"]
-color_identity = "G"
-types = ["creature"]
-tags = ["Land Graveyard - Payoff","Graveyard - Enabler","Landfall - Enabler"]
-
 ["Yavimaya Coast"]
 mana_cost = []
 color_identity = "C"
@@ -2246,16 +2192,16 @@ tags = []
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tokens - Enabler","ETB - Enabler"]
+tags = ["Tokens - Enabler","Tier 3"]
 
 ["Young Pyromancer"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Signpost","Spells - Payoff","Tokens - Enabler"]
+tags = ["Signpost","Spells - Payoff","Tokens - Enabler","Tier 2"]
 
 ["Yuriko, the Tiger's Shadow"]
 mana_cost = ["1","U","B"]
 color_identity = "BU"
 types = ["creature"]
-tags = ["Ninjutsu - Payoff","Signpost","Higher Toughness"]
+tags = ["Ninjutsu - Payoff","Signpost","Higher Toughness","Tier 2"]

--- a/tests/data/test_greedy_power_and_synergy_picker_cards.toml
+++ b/tests/data/test_greedy_power_and_synergy_picker_cards.toml
@@ -1,0 +1,35 @@
+["Abzan Battle Priest"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Counters - Payoff","Keyword","Lifegain - Enabler","Counters - Enabler","Tier 3"]
+
+["Ajani's Pridemate"]
+mana_cost = ["1","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Lifegain - Payoff","Tier 3"]
+
+["Lightning Helix"]
+mana_cost = ["R","W"]
+color_identity = "RW"
+types = ["instant"]
+tags = ["Removal","Lifegain - Enabler","Spells - Enabler","Tier 1"]
+
+["Ayli, Eternal Pilgrim"]
+mana_cost = ["W","B"]
+color_identity = "BW"
+types = ["creature"]
+tags = ["Signpost","Lifegain - Enabler","Lifegain - Payoff","Higher Toughness","Tier 1"]
+
+["Tuskguard Captain"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword","Tier 3"]
+
+["Swift Justice"]
+mana_cost = ["W"]
+color_identity = "W"
+types = ["instant"]
+tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler","Tier 3"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 import mock
 import pytest
-from mtg_draft_ai.api import Drafter, Packs, DraftInfo, Picker
+from mtg_draft_ai.api import Drafter, Packs, DraftInfo, Picker, Card
 
 
 PICKED_CARD = 1
@@ -47,3 +47,17 @@ def test_invalid_picker():
 
     with pytest.raises(TypeError):
         InvalidPicker()
+
+
+def test_card_from_raw_data():
+    name = 'Abhorrent Overlord'
+    props = {
+        'color_identity': 'B',
+        'tags': ['Reanimator - Payoff', 'Big', 'Keyword', 'Tier 2', 'Ramp - Payoff']
+    }
+    card = Card.from_raw_data(name, props)
+
+    assert card.name == name
+    assert card.color_id == 'B'
+    assert card.power_tier == 2
+    assert card.tags == [('Reanimator', 'Payoff'), ('Ramp', 'Payoff')]

--- a/tests/test_greedy_power_and_synergy_picker.py
+++ b/tests/test_greedy_power_and_synergy_picker.py
@@ -1,0 +1,81 @@
+import mock
+import os
+import pytest
+from mtg_draft_ai.brains import GreedyPowerAndSynergyPicker, _CombinedRating
+from mtg_draft_ai.api import *
+from mtg_draft_ai import synergy
+
+
+TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+
+# Cards:
+# Abzan Battle Priest, Ajani's Pridemate, Lightning Helix, "Ayli, Eternal Pilgrim",
+# Tuskguard Captain, Swift Justice
+@pytest.fixture
+def cards():
+    file_path = os.path.join(TEST_DATA_DIR, 'test_greedy_power_and_synergy_picker_cards.toml')
+    return read_cube_toml(file_path)
+
+
+@pytest.fixture
+def cards_by_name(cards):
+    return {c.name: c for c in cards}
+
+
+@pytest.fixture
+def graph(cards):
+    return synergy.create_graph(cards)
+
+
+@pytest.fixture
+def draft_info():
+    return mock.Mock(name='draft_info')
+
+
+def test_normalize_ratings():
+    raw_ratings = [
+        _CombinedRating('card1', 'W', None, power_delta=0.8, total_power=10, edges_delta=5,
+                        total_edges=50, common_neighbors_weighted=10),
+        _CombinedRating('card2', 'U', None, 0.6, 8, 4, 40, 8),
+        _CombinedRating('card3', 'B', None, 0.3, 6, 3, 30, 6),
+    ]
+
+    expected = [
+        _CombinedRating('card1', 'W', None, 1.0, 1.0, 1.0, 1.0, 1.0),
+        _CombinedRating('card2', 'U', None, 0.75, 0.8, 0.8, 0.8, 0.8),
+        _CombinedRating('card3', 'B', None, 0.375, 0.6, 0.6, 0.6, 0.6),
+    ]
+
+    normalized_ratings = GreedyPowerAndSynergyPicker._normalize_ratings(raw_ratings)
+    assert normalized_ratings == expected
+
+
+def test_composite_ratings():
+    normalized_ratings = [
+        _CombinedRating('card1', 'W', rating=None, power_delta=1.0, total_power=1.0, edges_delta=1.0,
+                        total_edges=1.0, common_neighbors_weighted=1.0),
+        _CombinedRating('card2', 'U', None, 0.0, 0.2, 0.3, 0.4, 0.5),
+    ]
+
+    expected = [
+        _CombinedRating('card1', 'W', rating=1.0, power_delta=1.0, total_power=1.0, edges_delta=1.0,
+                        total_edges=1.0, common_neighbors_weighted=1.0),
+        # Expected: power rating = 0.1 and synergy rating = 0.4 -> composite = 0.25
+        _CombinedRating('card2', 'U', 0.25, 0.0, 0.2, 0.3, 0.4, 0.5),
+    ]
+
+    composite_ratings = GreedyPowerAndSynergyPicker._composite_ratings(normalized_ratings)
+    assert composite_ratings == expected
+
+
+def test_greedy_power_and_synergy_picker(cards, cards_by_name, draft_info):
+    picker = GreedyPowerAndSynergyPicker.factory(cards).create()
+    owned_card_names = ['Abzan Battle Priest', "Ajani's Pridemate"]
+    pack_card_names = ['Ayli, Eternal Pilgrim', 'Tuskguard Captain']
+    owned_cards = [cards_by_name[n] for n in owned_card_names]
+    pack = [cards_by_name[n] for n in pack_card_names]
+
+    pick = picker.pick(pack, owned_cards, draft_info)
+    assert pick == cards_by_name['Ayli, Eternal Pilgrim']
+

--- a/tests/test_greedy_synergy_picker.py
+++ b/tests/test_greedy_synergy_picker.py
@@ -1,12 +1,13 @@
 import mock
 import os
 import pytest
-from mtg_draft_ai.brains import GreedySynergyPicker, all_common_neighbors
+from mtg_draft_ai.brains import GreedySynergyPicker, all_common_neighbors, _GSPRating
 from mtg_draft_ai.api import *
 from mtg_draft_ai import synergy
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
 
 # Cards:
 # Abzan Battle Priest, Ajani's Pridemate, Lightning Helix, "Ayli, Eternal Pilgrim",
@@ -65,8 +66,10 @@ def test_greedy_synergy_picker(cards, cards_by_name, draft_info):
     assert len(ratings) == 5
 
     top_ranked = ratings[0]
-    assert top_ranked.card == cards_by_name['Ayli, Eternal Pilgrim']
     # Expected:
     # total edges: priest/pridemate/ayli all connected
     # common neighbors (not already in pool): swift justice
-    assert top_ranked[1:] == ('WB', 3, 1, picker.default_ratings[top_ranked.card])
+    # edges delta: 2 (ayli + priest, ayli + pridemate)
+    expected = _GSPRating(cards_by_name['Ayli, Eternal Pilgrim'], 'WB', total_edges=3, common_neighbors_weighted=1,
+                          edges_delta=2, default=picker.default_ratings[top_ranked.card])
+    assert top_ranked == expected

--- a/trials.py
+++ b/trials.py
@@ -18,7 +18,7 @@ def main():
 
     cube_list = read_cube_toml(args.card_data)
     draft_info = DraftInfo(card_list=cube_list, num_drafters=6, num_phases=3, cards_per_pack=15)
-    drafter_factory = GreedySynergyPicker.factory(cube_list)
+    drafter_factory = GreedyPowerAndSynergyPicker.factory(cube_list)
 
     edge_counts = []
     for i in range(0, args.n):

--- a/website/draft_site/drafts/cube_81183_tag_data.toml
+++ b/website/draft_site/drafts/cube_81183_tag_data.toml
@@ -2,19 +2,13 @@
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler","Tier 2"]
+tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler","Tier 2","Ramp - Payoff"]
 
 ["Abzan Battle Priest"]
 mana_cost = ["3","W"]
 color_identity = "W"
 types = ["creature"]
 tags = ["Counters - Payoff","Keyword","Lifegain - Enabler","Counters - Enabler","Tier 3"]
-
-["Accorder Paladin"]
-mana_cost = ["1","W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Tokens - Payoff","Keyword","Tier 2"]
 
 ["Adarkar Wastes"]
 mana_cost = []
@@ -26,7 +20,7 @@ tags = []
 mana_cost = ["1","U","R"]
 color_identity = "UR"
 types = ["creature"]
-tags = ["Spells - Payoff","Wizards - Payoff","Wizards - Enabler","Tier 1"]
+tags = ["Spells - Payoff","Wizards - Payoff","Wizards - Enabler","Tier 2"]
 
 ["Ajani's Pridemate"]
 mana_cost = ["1","W"]
@@ -44,7 +38,7 @@ tags = ["Heroic - Payoff","Keyword","Tier 4"]
 mana_cost = ["W","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Enabler","Keyword","Spirits - Enabler","ETB - Enabler","Tier 1"]
+tags = ["Counters - Enabler","Keyword","Spirits - Enabler","ETB - Enabler","Tier 2"]
 
 ["Anax and Cymede"]
 mana_cost = ["1","W","R"]
@@ -63,12 +57,6 @@ mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
 tags = ["Heroic - Enabler","Tier 3"]
-
-["Anowon, the Ruin Sage"]
-mana_cost = ["3","B","B"]
-color_identity = "B"
-types = ["creature"]
-tags = ["Vampires - Enabler","Vampires - Payoff","Sacrifice - Payoff","Signpost","Tier 3","cuttable"]
 
 ["Armorcraft Judge"]
 mana_cost = ["3","G"]
@@ -98,7 +86,7 @@ tags = ["ETB - Enabler","Ninjutsu - Enabler","Tier 3"]
 mana_cost = ["1","R"]
 color_identity = "R"
 types = ["sorcery"]
-tags = ["Signpost","Madness/Hellbent - Payoff","Spells - Enabler","Removal - Size","Removal","Tier 3"]
+tags = ["Signpost","Madness/Hellbent - Payoff","Spells - Enabler","Removal - Size","Removal","Tier 3","Keyword"]
 
 ["Avaricious Dragon"]
 mana_cost = ["2","R","R"]
@@ -118,17 +106,11 @@ color_identity = "U"
 types = ["creature"]
 tags = ["Signpost","Wizards - Payoff","Wizards - Enabler","Card Draw","Tier 1"]
 
-["Azorius Herald"]
-mana_cost = ["2","W"]
-color_identity = "UW"
-types = ["creature"]
-tags = ["Spirits - Enabler","Lifegain - Enabler","ETB - Enabler","Tier 2"]
-
 ["Azorius Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Azra Oddsmaker"]
 mana_cost = ["1","B","R"]
@@ -140,19 +122,13 @@ tags = ["Card Draw","Madness/Hellbent - Enabler","Tier 1","Spice"]
 mana_cost = ["W"]
 color_identity = "W"
 types = ["instant"]
-tags = ["Tier 2","Heroic - Enabler"]
+tags = ["Heroic - Enabler","Spells - Enabler","Tier 3"]
 
 ["Banisher Priest"]
 mana_cost = ["1","W","W"]
 color_identity = "W"
 types = ["creature"]
 tags = ["Removal","ETB - Enabler","Tier 2"]
-
-["Banishing Light"]
-mana_cost = ["2","W"]
-color_identity = "W"
-types = ["enchantment"]
-tags = ["Removal","Tier 2","Noncreature Permanent Interaction"]
 
 ["Battlefield Forge"]
 mana_cost = []
@@ -170,7 +146,7 @@ tags = ["Signpost","Spells - Payoff","Higher Toughness","Big","Keyword","Card Dr
 mana_cost = ["G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Ninjutsu - Enabler","Tier 1"]
+tags = ["Ninjutsu - Enabler","Tier 1","Ramp - Enabler"]
 
 ["Bishop of Rebirth"]
 mana_cost = ["3","W","W"]
@@ -194,7 +170,7 @@ tags = ["Signpost","Big","Keyword","Vampires - Enabler","Madness/Hellbent - Payo
 mana_cost = ["4","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Payoff","Vampires - Enabler","Wizards - Payoff","Wizards - Enabler","Tier 1","Spice"]
+tags = ["Lifegain - Enabler","ETB - Enabler","Vampires - Payoff","Vampires - Enabler","Wizards - Payoff","Wizards - Enabler","Spice","Tier 2"]
 
 ["Bloodmist Infiltrator"]
 mana_cost = ["2","B"]
@@ -212,7 +188,7 @@ tags = ["Madness/Hellbent - Enabler","Tier 3"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Keyword","Tier 2"]
+tags = ["Sacrifice - Enabler","Keyword","Tier 2","Madness/Hellbent - Payoff"]
 
 ["Bloodspore Thrinax"]
 mana_cost = ["2","G","G"]
@@ -248,13 +224,13 @@ tags = ["Removal","Sacrifice - Payoff","Tier 4"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Bound by Moonsilver"]
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Removal","Keyword","Heroic - Enabler","Tier 2"]
+tags = ["Removal","Keyword","Heroic - Enabler","Tier 3"]
 
 ["Bounding Krasis"]
 mana_cost = ["1","U","G"]
@@ -290,7 +266,7 @@ tags = []
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Land Graveyard - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Creature) - Payoff"]
+tags = ["Land Graveyard - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Creature) - Payoff","Tier 3"]
 
 ["Burning Prophet"]
 mana_cost = ["1","R"]
@@ -303,6 +279,12 @@ mana_cost = ["2","W","B"]
 color_identity = "BW"
 types = ["sorcery"]
 tags = ["Tokens - Enabler","Lifegain - Enabler","Vampires - Enabler","Tier 3"]
+
+["Camaraderie"]
+mana_cost = ["4","G","W"]
+color_identity = "GW"
+types = ["sorcery"]
+tags = ["Spice","Tier 2","Signpost","Tokens - Payoff"]
 
 ["Cathartic Reunion"]
 mana_cost = ["1","R"]
@@ -382,23 +364,23 @@ color_identity = "G"
 types = ["sorcery"]
 tags = ["Graveyard - Enabler","Tier 2"]
 
+["Conclave Tribunal"]
+mana_cost = ["3","W"]
+color_identity = "W"
+types = ["enchantment"]
+tags = ["Tier 2","Removal","Tokens - Payoff"]
+
 ["Countryside Crusher"]
 mana_cost = ["1","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Land Graveyard - Payoff","Land Graveyard - Enabler","Big","Tier 2"]
+tags = ["Tier 3","Land Graveyard - Enabler","Land Graveyard - Payoff"]
 
 ["Crawling Sensation"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["enchantment"]
 tags = ["Graveyard - Enabler","Land Graveyard - Payoff","Tier 4"]
-
-["Crested Herdcaller"]
-mana_cost = ["3","G","G"]
-color_identity = "G"
-types = ["creature"]
-tags = ["Tokens - Enabler","ETB - Enabler","Tier 2"]
 
 ["Crested Sunmare"]
 mana_cost = ["3","W","W"]
@@ -446,7 +428,7 @@ tags = ["Big","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifac
 mana_cost = ["U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Card Draw","Tier 1"]
+tags = ["Heroic - Enabler","Card Draw","Tier 1","Ninjutsu - Payoff"]
 
 ["Dark-Dweller Oracle"]
 mana_cost = ["1","R"]
@@ -470,13 +452,13 @@ tags = ["ETB - Enabler","Removal","Tier 3"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tier 2"]
+tags = ["Tier 2","Ramp - Enabler"]
 
 ["Dimir Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Dinrova Horror"]
 mana_cost = ["4","U","B"]
@@ -512,7 +494,7 @@ tags = ["Trick","Heroic - Enabler","Spells - Enabler","Flash - Interaction","Tie
 mana_cost = ["3","W","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Signpost","Spice","Tier 2","Tokens - Payoff"]
+tags = ["Signpost","Spice","Tokens - Payoff","Tier 1"]
 
 ["Dragon Mantle"]
 mana_cost = ["R"]
@@ -531,6 +513,12 @@ mana_cost = ["2","U"]
 color_identity = "U"
 types = ["enchantment"]
 tags = ["Signpost","Madness/Hellbent - Payoff","Tier 3","Spice"]
+
+["Drogskol Captain"]
+mana_cost = ["1","W","U"]
+color_identity = "UW"
+types = ["creature"]
+tags = ["Signpost","Tier 2","Spirits - Enabler","Spirits - Payoff"]
 
 ["Drowned Catacomb"]
 mana_cost = []
@@ -554,7 +542,7 @@ tags = ["Sacrifice - Enabler","ETB - Enabler","Tier 3"]
 mana_cost = ["X","U"]
 color_identity = "U"
 types = ["instant"]
-tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler","Flash - Threat","Tier 3"]
+tags = ["Graveyard - Enabler","Card Draw","Spells - Enabler","Flash - Threat","Tier 3","Ramp - Payoff"]
 
 ["Essence Flux"]
 mana_cost = ["U"]
@@ -578,7 +566,7 @@ tags = ["Landfall - Enabler","Graveyard - Enabler","Madness/Hellbent - Enabler",
 mana_cost = ["X","X","R"]
 color_identity = "R"
 types = ["instant"]
-tags = ["Removal","Heroic - Enabler","Keyword","Spells - Enabler","Removal - Size","Tier 1"]
+tags = ["Removal","Heroic - Enabler","Keyword","Spells - Enabler","Removal - Size","Tier 1","Ramp - Payoff"]
 
 ["Familiar's Ruse"]
 mana_cost = ["U","U"]
@@ -616,6 +604,12 @@ color_identity = "BR"
 types = ["creature"]
 tags = ["Sacrifice - Payoff","Tier 3"]
 
+["Fists of Flame"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["instant"]
+tags = ["Heroic - Enabler","Spells - Enabler","Tier 2","Spice","Trick"]
+
 ["Fists of Ironwood"]
 mana_cost = ["1","G"]
 color_identity = "G"
@@ -638,13 +632,13 @@ tags = []
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler"]
+tags = ["Tokens - Enabler","Land Graveyard - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Tier 3"]
 
 ["Gallant Cavalry"]
 mana_cost = ["3","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["ETB - Enabler","Tokens - Enabler","Tier 3","cuttable"]
+tags = ["ETB - Enabler","Tokens - Enabler","cuttable","Tier 4"]
 
 ["Gather the Townsfolk"]
 mana_cost = ["1","W"]
@@ -662,7 +656,7 @@ tags = ["Counters - Enabler","Counters - Payoff","Higher Toughness","Keyword","E
 mana_cost = ["X","G","G","G"]
 color_identity = "G"
 types = ["sorcery"]
-tags = ["Big","Tier 3"]
+tags = ["Big","Tier 3","Ramp - Payoff"]
 
 ["Ghitu Lavarunner"]
 mana_cost = ["R"]
@@ -710,7 +704,7 @@ tags = ["Tokens - Enabler","Sacrifice - Enabler","Tier 4"]
 mana_cost = ["3","R"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Land Graveyard - Enabler","Tier 3"]
+tags = ["Land Graveyard - Enabler","Tier 3","Ramp - Enabler"]
 
 ["Goblin Instigator"]
 mana_cost = ["1","R"]
@@ -728,7 +722,7 @@ tags = ["Signpost","Artifacts - Payoff","Tier 2","Spice"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Gonti, Lord of Luxury"]
 mana_cost = ["2","B","B"]
@@ -736,11 +730,17 @@ color_identity = "B"
 types = ["creature"]
 tags = ["Higher Toughness","ETB - Enabler","Tier 1"]
 
+["Good-Fortune Unicorn"]
+mana_cost = ["1","G","W"]
+color_identity = "GW"
+types = ["creature"]
+tags = ["Counters - Enabler","Tokens - Payoff","Tier 3"]
+
 ["Grateful Apparition"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Payoff","Spirits - Enabler","Ninjutsu - Enabler","Tier 3"]
+tags = ["Counters - Payoff","Spirits - Enabler","Ninjutsu - Enabler","Tier 3","Keyword"]
 
 ["Graveyard Marshal"]
 mana_cost = ["B","B"]
@@ -758,7 +758,7 @@ tags = ["Lifegain - Enabler","Landfall - Payoff","Tier 3"]
 mana_cost = ["4","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Big","ETB - Enabler","Tier 1"]
+tags = ["Graveyard - Payoff","Big","ETB - Enabler","Tier 1","Ramp - Payoff"]
 
 ["Gruesome Menagerie"]
 mana_cost = ["3","B","B"]
@@ -770,7 +770,7 @@ tags = ["Graveyard - Payoff","Tier 2","Spice"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Gyre Sage"]
 mana_cost = ["1","G"]
@@ -812,7 +812,7 @@ tags = ["Tokens - Enabler","Graveyard - Payoff","Spirits - Enabler","ETB - Enabl
 mana_cost = ["4"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Tier 2"]
+tags = ["Card Draw","Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Tier 2","Ramp - Enabler"]
 
 ["Heir of Falkenrath"]
 mana_cost = ["1","B"]
@@ -854,7 +854,7 @@ tags = ["Counters - Enabler","Counters - Payoff","Tokens - Enabler","Tier 2","Sp
 mana_cost = []
 color_identity = "C"
 types = ["land"]
-tags = ["Land Graveyard - Payoff"]
+tags = ["Land Graveyard - Payoff","Tier 3"]
 
 ["Illusionist's Stratagem"]
 mana_cost = ["3","U"]
@@ -872,19 +872,13 @@ tags = ["Removal","Spells - Enabler","Removal - Size","Tier 2"]
 mana_cost = ["1","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tier 1","Counters - Payoff","Flash - Threat"]
+tags = ["Tier 1","Counters - Payoff","Flash - Threat","Keyword","Ramp - Enabler"]
 
 ["Indulgent Aristocrat"]
 mana_cost = ["B"]
 color_identity = "B"
 types = ["creature"]
 tags = ["Sacrifice - Payoff","Lifegain - Enabler","Counters - Enabler","Vampires - Enabler","Vampires - Payoff","Tier 3"]
-
-["Inferno Fist"]
-mana_cost = ["1","R"]
-color_identity = "R"
-types = ["enchantment"]
-tags = ["Tier 3","Heroic - Enabler","Removal","Removal - Size"]
 
 ["Inspiring Cleric"]
 mana_cost = ["2","W"]
@@ -914,7 +908,7 @@ tags = ["Spells - Payoff","Graveyard - Payoff","Signpost","Higher Toughness","Wi
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Jace's Archivist"]
 mana_cost = ["1","U","U"]
@@ -938,13 +932,7 @@ tags = ["Higher Toughness","Wizards - Enabler","Card Draw","Tier 2","Spice"]
 mana_cost = ["1","B","R"]
 color_identity = "BR"
 types = ["creature"]
-tags = ["Sacrifice - Payoff","Signpost","Tier 1","Spice"]
-
-["Juniper Order Ranger"]
-mana_cost = ["3","G","W"]
-color_identity = "GW"
-types = ["creature"]
-tags = ["Counters - Enabler","Tokens - Payoff","ETB - Enabler","Higher Toughness","Tier 3"]
+tags = ["Sacrifice - Payoff","Signpost","Spice","Tier 2"]
 
 ["Kalastria Highborn"]
 mana_cost = ["B","B"]
@@ -986,7 +974,7 @@ tags = []
 mana_cost = ["4","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Graveyard - Payoff","Signpost","Higher Toughness","Big","Tier 2"]
+tags = ["Graveyard - Payoff","Signpost","Higher Toughness","Big","Tier 1"]
 
 ["Key to the City"]
 mana_cost = ["2"]
@@ -1017,12 +1005,6 @@ mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
 tags = ["Ninjutsu - Enabler","Tier 2","Noncreature Permanent Interaction"]
-
-["Knotvine Paladin"]
-mana_cost = ["G","W"]
-color_identity = "GW"
-types = ["creature"]
-tags = ["Tokens - Payoff","Tier 2"]
 
 ["Lantern Kami"]
 mana_cost = ["W"]
@@ -1064,7 +1046,7 @@ tags = ["Big","Flash - Threat","Tier 2"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Tier 3","Madness/Hellbent - Payoff","Artifacts (Cheap) - Enabler","Artifacts (Creature) - Enabler","Artifacts - Enabler"]
+tags = ["Madness/Hellbent - Payoff","Artifacts (Cheap) - Enabler","Artifacts (Creature) - Enabler","Artifacts - Enabler","Tier 4"]
 
 ["Magma Burst"]
 mana_cost = ["3","R"]
@@ -1076,7 +1058,7 @@ tags = ["Keyword","Land Graveyard - Enabler","Removal","Spells - Enabler","Remov
 mana_cost = ["5","R","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Big","Reanimator - Payoff","Tier 3"]
+tags = ["Big","Reanimator - Payoff","Tier 3","Ramp - Payoff"]
 
 ["Magmatic Insight"]
 mana_cost = ["R"]
@@ -1138,11 +1120,17 @@ color_identity = "C"
 types = ["land"]
 tags = []
 
+["Memorial to Glory"]
+mana_cost = []
+color_identity = "C"
+types = ["land"]
+tags = ["Land Graveyard - Enabler","Tokens - Enabler","Tier 3"]
+
 ["Memorial to Unity"]
 mana_cost = []
 color_identity = "G"
 types = ["land"]
-tags = ["Land Graveyard - Enabler"]
+tags = ["Land Graveyard - Enabler","Tier 3"]
 
 ["Metallic Mimic"]
 mana_cost = ["2"]
@@ -1196,7 +1184,7 @@ tags = ["Card Draw","Madness/Hellbent - Payoff","Artifacts - Enabler","Artifacts
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Tier 2","Tokens - Enabler","Sacrifice - Enabler"]
+tags = ["Tokens - Enabler","Sacrifice - Enabler","Keyword","Tier 3"]
 
 ["Mirror Mockery"]
 mana_cost = ["1","U"]
@@ -1215,6 +1203,12 @@ mana_cost = ["R"]
 color_identity = "R"
 types = ["enchantment"]
 tags = ["Land Graveyard - Enabler","Removal","Removal - Size","Tier 2"]
+
+["Mother Bear"]
+mana_cost = ["1","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Graveyard - Payoff","Tokens - Enabler","Tier 3"]
 
 ["Murderous Cut"]
 mana_cost = ["4","B"]
@@ -1262,7 +1256,7 @@ tags = ["Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent
 mana_cost = ["3","R","R"]
 color_identity = "R"
 types = ["creature"]
-tags = ["Higher Toughness","Big","Keyword","Tier 2"]
+tags = ["Higher Toughness","Big","Keyword","Tier 2","Ramp - Enabler"]
 
 ["Niblis of the Urn"]
 mana_cost = ["1","W"]
@@ -1304,13 +1298,7 @@ tags = ["Ninjutsu - Payoff","Tier 3"]
 mana_cost = ["3","R","R","G","G"]
 color_identity = "GR"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Landfall - Payoff","Keyword","Tier 2"]
-
-["One Dozen Eyes"]
-mana_cost = ["5","G"]
-color_identity = "G"
-types = ["sorcery"]
-tags = ["Tokens - Enabler","Tier 2"]
+tags = ["Reanimator - Payoff","Big","Landfall - Payoff","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Oppressive Rays"]
 mana_cost = ["W"]
@@ -1328,25 +1316,25 @@ tags = ["Spells - Enabler","Tier 2"]
 mana_cost = ["3","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Landfall - Enabler","Tier 1","Spice"]
+tags = ["Landfall - Enabler","Tier 1","Spice","Ramp - Enabler"]
 
 ["Ordeal of Heliod"]
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Lifegain - Enabler","Counters - Enabler","Tier 3"]
+tags = ["Heroic - Enabler","Lifegain - Enabler","Counters - Enabler","Tier 4"]
 
 ["Ordeal of Thassa"]
 mana_cost = ["1","U"]
 color_identity = "U"
 types = ["enchantment"]
-tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw","Tier 2"]
+tags = ["Heroic - Enabler","Counters - Enabler","Counters - Payoff","Card Draw","Ninjutsu - Payoff","Tier 3"]
 
 ["Orzhov Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Outnumber"]
 mana_cost = ["R"]
@@ -1376,7 +1364,7 @@ tags = ["Land Graveyard - Enabler","Spirits - Enabler","Flash - Threat","Tier 2"
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact","creature"]
-tags = ["Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2"]
+tags = ["Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 2","Ramp - Enabler"]
 
 ["Panharmonicon"]
 mana_cost = ["4"]
@@ -1388,7 +1376,7 @@ tags = ["Signpost","ETB - Payoff","Artifacts - Enabler","Artifacts (Noncreature)
 mana_cost = ["2","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Lifegain - Enabler","Lifegain - Payoff","Tokens - Payoff","Tier 2"]
+tags = ["Lifegain - Enabler","Lifegain - Payoff","Tokens - Payoff","Tier 3"]
 
 ["Path of Discovery"]
 mana_cost = ["3","G"]
@@ -1418,7 +1406,7 @@ tags = ["Signpost","Heroic - Payoff","Counters - Enabler","Keyword","Tier 2","Sp
 mana_cost = ["1","W"]
 color_identity = "W"
 types = ["creature"]
-tags = ["Counters - Enabler","Spirits - Enabler","Tier 2"]
+tags = ["Counters - Enabler","Spirits - Enabler","Tier 3"]
 
 ["Pianna, Nomad Captain"]
 mana_cost = ["1","W","W"]
@@ -1438,12 +1426,6 @@ color_identity = "C"
 types = ["artifact"]
 tags = ["Keyword","Artifacts - Enabler","Artifacts (Cheap) - Payoff","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
 
-["Pongify"]
-mana_cost = ["U"]
-color_identity = "U"
-types = ["instant"]
-tags = ["Removal","Trick","Flash - Threat","Spells - Enabler","Tier 4","cuttable"]
-
 ["Pore Over the Pages"]
 mana_cost = ["3","U","U"]
 color_identity = "U"
@@ -1460,7 +1442,7 @@ tags = ["ETB - Enabler","Tier 2"]
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["enchantment"]
-tags = ["Tokens - Enabler","Heroic - Enabler","Tier 4"]
+tags = ["Tokens - Enabler","Heroic - Enabler","Tier 4","cuttable"]
 
 ["Prey Upon"]
 mana_cost = ["G"]
@@ -1478,7 +1460,7 @@ tags = ["Signpost","Higher Toughness","Wizards - Enabler","Flash - Threat","Tier
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Noncreature) - Enabler","Artifacts (Cheap) - Enabler","Tier 4"]
 
 ["Pyrite Spellbomb"]
 mana_cost = ["1"]
@@ -1502,7 +1484,7 @@ tags = ["ETB - Payoff","Ninjutsu - Enabler","Flash - Threat","Tier 3"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Ramunap Excavator"]
 mana_cost = ["2","G"]
@@ -1532,7 +1514,7 @@ tags = ["Counters - Enabler","Tier 3"]
 mana_cost = ["1","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Sacrifice - Enabler","Graveyard - Payoff","Tier 2"]
+tags = ["Sacrifice - Enabler","Graveyard - Payoff","Tier 2","Madness/Hellbent - Payoff"]
 
 ["Reckless Racer"]
 mana_cost = ["2","R"]
@@ -1568,13 +1550,13 @@ tags = ["Graveyard - Payoff","Spells - Payoff","Signpost","Big","Spells - Enable
 mana_cost = ["2","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Counters - Enabler","ETB - Enabler","Tier 1"]
+tags = ["Counters - Enabler","ETB - Enabler","Tier 1","Ramp - Enabler"]
 
 ["River Hoopoe"]
 mana_cost = ["G","U"]
 color_identity = "GU"
 types = ["creature"]
-tags = ["Lifegain - Enabler","Flash - Threat","Card Draw","Higher Toughness","Ninjutsu - Enabler","Tier 4"]
+tags = ["Lifegain - Enabler","Flash - Threat","Card Draw","Higher Toughness","Ninjutsu - Enabler","Tier 3","Ramp - Payoff"]
 
 ["Rootbound Crag"]
 mana_cost = []
@@ -1592,7 +1574,13 @@ tags = ["Graveyard - Enabler","ETB - Enabler","Card Draw","Madness/Hellbent - En
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Keyword","Card Draw","Tier 2"]
+tags = ["Keyword","Card Draw","Tier 2","Ninjutsu - Payoff"]
+
+["Runaway Steam-Kin"]
+mana_cost = ["1","R"]
+color_identity = "R"
+types = ["creature"]
+tags = ["Tier 2","Spice"]
 
 ["Sai, Master Thopterist"]
 mana_cost = ["2","U"]
@@ -1634,7 +1622,7 @@ tags = ["Keyword","Madness/Hellbent - Payoff","Tier 2"]
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Signpost","Big","Tier 2","Spice"]
+tags = ["Reanimator - Payoff","Signpost","Big","Spice","Madness/Hellbent - Payoff","Graveyard - Payoff","Tier 1"]
 
 ["Scrounging Bandar"]
 mana_cost = ["1","G"]
@@ -1654,12 +1642,6 @@ color_identity = "W"
 types = ["enchantment"]
 tags = ["Removal","Tier 3"]
 
-["Second Harvest"]
-mana_cost = ["2","G","G"]
-color_identity = "G"
-types = ["instant"]
-tags = ["Tokens - Payoff","Signpost","Tier 4"]
-
 ["Selesnya Evangel"]
 mana_cost = ["G","W"]
 color_identity = "GW"
@@ -1670,7 +1652,7 @@ tags = ["Tokens - Enabler","Higher Toughness","Tier 2"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Shivan Reef"]
 mana_cost = []
@@ -1682,25 +1664,19 @@ tags = []
 mana_cost = ["1","B","G","U"]
 color_identity = "BGU"
 types = ["creature"]
-tags = ["Signpost","Graveyard - Enabler","Graveyard - Payoff","Tier 1"]
+tags = ["Signpost","Graveyard - Enabler","Graveyard - Payoff","Tier 2"]
 
 ["Sifter Wurm"]
 mana_cost = ["5","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Big","ETB - Enabler","Tier 3"]
-
-["Signal Pest"]
-mana_cost = ["1"]
-color_identity = "C"
-types = ["artifact","creature"]
-tags = ["Ninjutsu - Enabler","Artifacts - Enabler","Tokens - Payoff","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 4"]
+tags = ["Big","ETB - Enabler","Tier 3","Ramp - Payoff"]
 
 ["Simic Signet"]
 mana_cost = ["2"]
 color_identity = "C"
 types = ["artifact"]
-tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler"]
+tags = ["Artifacts - Enabler","Artifacts (Cheap) - Enabler","Artifacts (Noncreature) - Enabler","Ramp - Enabler","Tier 2"]
 
 ["Sin Prodder"]
 mana_cost = ["2","R"]
@@ -1744,17 +1720,17 @@ color_identity = "G"
 types = ["creature"]
 tags = ["Tokens - Payoff","Counters - Enabler","Keyword","ETB - Enabler","Sacrifice - Payoff","Card Draw","Tier 1","Spice"]
 
-["Skymarcher Aspirant"]
-mana_cost = ["W"]
-color_identity = "W"
-types = ["creature"]
-tags = ["Keyword","Vampires - Enabler","Tier 3"]
-
 ["Skyscanner"]
 mana_cost = ["3"]
 color_identity = "C"
 types = ["artifact","creature"]
 tags = ["Ninjutsu - Enabler","ETB - Enabler","Artifacts - Enabler","Artifacts (Creature) - Enabler","Artifacts (Cheap) - Enabler","Tier 3"]
+
+["Smoke Shroud"]
+mana_cost = ["1","U"]
+color_identity = "U"
+types = ["enchantment"]
+tags = ["Ninjutsu - Enabler","Tier 3"]
 
 ["Soul's Fire"]
 mana_cost = ["2","R"]
@@ -1768,11 +1744,11 @@ color_identity = "W"
 types = ["creature"]
 tags = ["Signpost","Lifegain - Enabler","Spells - Payoff","Tier 1","Spice"]
 
-["Spectral Shepherd"]
-mana_cost = ["2","W"]
+["Soulherder"]
+mana_cost = ["1","W","U"]
 color_identity = "UW"
 types = ["creature"]
-tags = ["Spirits - Enabler","Spirits - Payoff","Ninjutsu - Enabler","Tier 4"]
+tags = ["Spirits - Enabler","ETB - Payoff","Signpost","Tier 2"]
 
 ["Spellgorger Weird"]
 mana_cost = ["2","R"]
@@ -1785,6 +1761,12 @@ mana_cost = ["3","G"]
 color_identity = "G"
 types = ["instant"]
 tags = ["Tokens - Enabler","Flash - Threat","Tier 3"]
+
+["Squirrel Wrangler"]
+mana_cost = ["2","G","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","Land Graveyard - Enabler","Tier 3"]
 
 ["Steel Overseer"]
 mana_cost = ["2"]
@@ -1868,7 +1850,7 @@ tags = ["Spells - Enabler","Flash - Interaction","Tier 3","Noncreature Permanent
 mana_cost = ["W"]
 color_identity = "W"
 types = ["instant"]
-tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler","Tier 2"]
+tags = ["Trick","Heroic - Enabler","Lifegain - Enabler","Spells - Enabler","Tier 3"]
 
 ["Tallowisp"]
 mana_cost = ["1","W"]
@@ -1946,7 +1928,7 @@ tags = ["Trick","Heroic - Enabler","Keyword","Spells - Enabler","Tier 3"]
 mana_cost = ["4","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Tokens - Enabler","Tokens - Payoff","Signpost","Tier 3"]
+tags = ["Tokens - Enabler","Tokens - Payoff","Signpost","Tier 3","Keyword"]
 
 ["Tenth District Legionnaire"]
 mana_cost = ["R","W"]
@@ -1958,7 +1940,7 @@ tags = ["Signpost","Tier 2","Heroic - Payoff"]
 mana_cost = ["2","G","G"]
 color_identity = "G"
 types = ["creature"]
-tags = ["Big","Keyword","Tier 2"]
+tags = ["Big","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Teysa, Orzhov Scion"]
 mana_cost = ["1","W","B"]
@@ -2002,6 +1984,12 @@ color_identity = "B"
 types = ["creature"]
 tags = ["Ninjutsu - Payoff","Removal","Tier 2"]
 
+["Throatseeker"]
+mana_cost = ["2","B"]
+color_identity = "B"
+types = ["creature"]
+tags = ["Ninjutsu - Payoff","Tier 3","Vampires - Enabler"]
+
 ["Tilling Treefolk"]
 mana_cost = ["2","G"]
 color_identity = "G"
@@ -2030,7 +2018,7 @@ tags = ["Land Graveyard - Payoff","Signpost","Tier 2","Spice"]
 mana_cost = ["W","W"]
 color_identity = "W"
 types = ["enchantment"]
-tags = ["Spice","Tier 1","Counters - Enabler","Counters - Payoff"]
+tags = ["Spice","Tier 1","Counters - Enabler","Counters - Payoff","Keyword"]
 
 ["Tower Geist"]
 mana_cost = ["3","U"]
@@ -2104,6 +2092,12 @@ color_identity = "B"
 types = ["enchantment"]
 tags = ["Lifegain - Enabler","Sacrifice - Payoff","Card Draw","Tier 2"]
 
+["Venerated Loxodon"]
+mana_cost = ["4","W"]
+color_identity = "W"
+types = ["creature"]
+tags = ["Signpost","Tier 1","Counters - Enabler","Tokens - Payoff"]
+
 ["Vengeful Rebel"]
 mana_cost = ["2","B"]
 color_identity = "B"
@@ -2114,7 +2108,7 @@ tags = ["Removal","Sacrifice - Payoff","Keyword","ETB - Enabler","Removal - Size
 mana_cost = ["2","B"]
 color_identity = "B"
 types = ["sorcery"]
-tags = ["Graveyard - Payoff","Reanimator - Enabler","Signpost","Tier 2","Spice"]
+tags = ["Graveyard - Payoff","Reanimator - Enabler","Signpost","Spice","Tier 1"]
 
 ["Viridian Zealot"]
 mana_cost = ["G","G"]
@@ -2132,7 +2126,7 @@ tags = ["Lifegain - Enabler","Lifegain - Payoff","Wizards - Enabler","Tier 2"]
 mana_cost = ["3","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Signpost","Vampires - Enabler","Tier 1","Spice","Madness/Hellbent - Payoff","Sacrifice - Payoff"]
+tags = ["Signpost","Vampires - Enabler","Tier 1","Spice","Madness/Hellbent - Payoff","Sacrifice - Payoff","Keyword"]
 
 ["Voyage's End"]
 mana_cost = ["1","U"]
@@ -2193,6 +2187,12 @@ mana_cost = []
 color_identity = "C"
 types = ["land"]
 tags = []
+
+["Yavimaya Sapherd"]
+mana_cost = ["2","G"]
+color_identity = "G"
+types = ["creature"]
+tags = ["Tokens - Enabler","Tier 3"]
 
 ["Young Pyromancer"]
 mana_cost = ["1","R"]

--- a/website/draft_site/drafts/cube_81183_tag_data.toml
+++ b/website/draft_site/drafts/cube_81183_tag_data.toml
@@ -2,7 +2,7 @@
 mana_cost = ["5","B","B"]
 color_identity = "B"
 types = ["creature"]
-tags = ["Reanimator - Payoff","Big","Keyword","ETB - Enabler","Tier 2","Ramp - Payoff"]
+tags = ["Reanimator - Payoff","Big","Keyword","Tier 2","Ramp - Payoff"]
 
 ["Abzan Battle Priest"]
 mana_cost = ["3","W"]

--- a/website/draft_site/drafts/views.py
+++ b/website/draft_site/drafts/views.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from . import models
 from mtg_draft_ai.controller import create_packs
 from mtg_draft_ai.api import DraftInfo, Drafter, read_cube_toml
-from mtg_draft_ai.brains import GreedySynergyPicker
+from mtg_draft_ai.brains import GreedyPowerAndSynergyPicker
 
 import requests
 import toml
@@ -22,7 +22,7 @@ import toml
 CUBE_FILE = os.path.join(settings.DRAFTS_APP_DIR, 'cube_81183_tag_data.toml')
 CUBE_LIST = read_cube_toml(CUBE_FILE)
 CARDS_BY_NAME = {c.name: c for c in CUBE_LIST}
-PICKER_FACTORY = GreedySynergyPicker.factory(CUBE_LIST)
+PICKER_FACTORY = GreedyPowerAndSynergyPicker.factory(CUBE_LIST)
 LOGGER = logging.getLogger(__name__)
 
 IMAGE_URLS_FILE = os.path.join(settings.DRAFTS_APP_DIR, 'cube_81183_image_urls.toml')


### PR DESCRIPTION
This version of the bot calculates a "power" rating and a "synergy" rating, both in the range [0, 1], and averages the two to create the final rating for each card. Then it picks the card with the highest rating.

The power rating is calculated by averaging the **normalized** versions of these values:
- power_delta: the "power" value of the candidate card
- total_power: the total "power" value of all the cards in the pool, plus the candidate card, for a color combination

The synergy rating is calculated by averaging the **normalized** versions of these values:
- edges_delta: the number of edges added to the pool if the candidate card is picked, for a color combination
- total_edges
- common_neighbors_weighted

There's room for tuning the arbitrarily-selected weights, both for translating power "tiers" into values, and for creating the final rating, but the defaults feel like they produce reasonable results so far.