### PR TITLE
Use graph communities to build deck

### DIFF
--- a/mtg_draft_ai/api.py
+++ b/mtg_draft_ai/api.py
@@ -7,7 +7,7 @@ import toml
 class Card:
     """Identifying information and other relevant attributes of a single Magic card."""
 
-    def __init__(self, name, color_id=None, tags=None, power_tier=None):
+    def __init__(self, name, color_id=None, types=None, tags=None, power_tier=None):
         """
         Args:
             name (str): The card's name.
@@ -23,6 +23,7 @@ class Card:
 
         self.name = name
         self.color_id = color_id
+        self.types = types
         self.tags = tags
         self.power_tier = power_tier
 
@@ -58,7 +59,8 @@ class Card:
                     k, v = split
                     tags.append((k.strip(), v.strip()))
 
-        return Card(name, color_id=properties['color_identity'], tags=tags, power_tier=power_tier)
+        return Card(name, color_id=properties['color_identity'], types=properties['types'],
+                    tags=tags, power_tier=power_tier)
 
 
 class Drafter:

--- a/mtg_draft_ai/api.py
+++ b/mtg_draft_ai/api.py
@@ -13,6 +13,7 @@ class Card:
             name (str): The card's name.
             color_id (str): The card's color identity, as read from cubetutor. E.g. a cube owner
                 can assign R for Bomat Courier.
+            types (List[str]): The card's supertypes.
             tags (List[(str, str)]): List of applicable tags for this card, as read from cubetutor.
                 Currently, only two-part tags are supported, in the format: <Category> - <Subcategory>
                 e.g.: Lifegain - Payoff

--- a/mtg_draft_ai/deckbuild.py
+++ b/mtg_draft_ai/deckbuild.py
@@ -20,8 +20,27 @@ def _num_nonlands(current_build):
 
 
 def _communities_build(card_pool_graph, target_playables):
+    """Builds a deck by trying combinations of communities. Ignores all other factors (including color).
+
+    Outline of algorithm:
+
+    1). Split the on-color cards into communities using networkx's greedy_modular_communities
+    2). Find the "best" community to add based on # of edges it would add / # nodes
+    3). Add the entire community to the pool
+    4). Repeat 2-3 until we have >= the target number of playables
+    5). Cut cards one by one based on lowest centrality score in the graph for the pool
+    until we have the target number of playables
+
+    Args:
+        card_pool_graph (networkx.Graph): A synergy graph of Cards as the card pool to build from.
+        target_playables (int): The number of nonland cards to include in the deck. Utility lands can still be
+            included if they are beneficial, but don't count towards this total.
+
+    Returns:
+        List[Card]: The build for the given pool pool of cards.
+    """
     if _num_nonlands(card_pool_graph.nodes) < target_playables:
-        raise DeckbuildError('Not enough cards')
+        raise DeckbuildError('Not enough nonland cards')
 
     communities = nx.algorithms.community.greedy_modularity_communities(card_pool_graph)
 
@@ -49,9 +68,11 @@ def _centralities_build(card_pool_graph, target_playables):
 
     Args:
         card_pool_graph (networkx.Graph): A synergy graph of Cards as the card pool to build from.
+        target_playables (int): The number of nonland cards to include in the deck. Utility lands can still be
+            included if they are beneficial, but don't count towards this total.
 
     Returns:
-        List[Card]: The build for that subset of the pool.
+        List[Card]: The build for the given pool pool of cards.
     """
     if len(card_pool_graph.nodes) < target_playables:
         raise DeckbuildError('Not enough cards')

--- a/mtg_draft_ai/synergy.py
+++ b/mtg_draft_ai/synergy.py
@@ -3,7 +3,7 @@
 import networkx as nx
 
 
-def create_graph(cards, remove_isolated=True):
+def create_graph(cards, remove_isolated=True, freeze=True):
     """Creates a synergy graph for the given list of card objects.
 
     Each card is a node, and two cards are connected by an edge if one tagged as an Enabler and
@@ -37,7 +37,8 @@ def create_graph(cards, remove_isolated=True):
 
     if remove_isolated:
         G.remove_nodes_from(list(nx.isolates(G)))
-    return nx.freeze(G)
+
+    return nx.freeze(G) if freeze else G
 
 
 def _cards_by_themes(cards):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -53,7 +53,8 @@ def test_card_from_raw_data():
     name = 'Abhorrent Overlord'
     props = {
         'color_identity': 'B',
-        'tags': ['Reanimator - Payoff', 'Big', 'Keyword', 'Tier 2', 'Ramp - Payoff']
+        'tags': ['Reanimator - Payoff', 'Big', 'Keyword', 'Tier 2', 'Ramp - Payoff'],
+        'types': ['Creature']
     }
     card = Card.from_raw_data(name, props)
 
@@ -61,3 +62,4 @@ def test_card_from_raw_data():
     assert card.color_id == 'B'
     assert card.power_tier == 2
     assert card.tags == [('Reanimator', 'Payoff'), ('Ramp', 'Payoff')]
+    assert card.types == ['Creature']

--- a/tests/test_deckbuild.py
+++ b/tests/test_deckbuild.py
@@ -32,7 +32,19 @@ def pool(cards_by_name):
 def test_deckbuild(pool):
     deck = deckbuild.best_two_color_synergy_build(pool)
 
-    assert len(deck) == deckbuild._NONLANDS_IN_DECK
+    assert len(deck) == deckbuild._NONLANDS_IN_DECK_DEFAULT
+
+    ur_cards_in_deck = [c for c in deck if synergy.castable(c, 'UR')]
+    assert deck == ur_cards_in_deck
+
+# Verifies that deckbuild will succeed even if there aren't enough playables in any color combination, and that it will
+# do a build for the color combination with the most playables in that case.
+def test_deckbuild_short_on_playables(cards_by_name):
+    card_names = ['Adeliz, the Cinder Wind', 'Harvest Pyre', 'Bloodrage Brawler', 'Thing in the Ice', 'Bound by Moonsilver']
+    card_pool = [cards_by_name[name] for name in card_names]
+    deck = deckbuild.best_two_color_synergy_build(card_pool)
+
+    assert len(deck) == 4
 
     ur_cards_in_deck = [c for c in deck if synergy.castable(c, 'UR')]
     assert deck == ur_cards_in_deck


### PR DESCRIPTION
The existing deckbuilding algorithm `_centralities_build` works by putting all on-color cards into one graph, computing centrality scores for all nodes, and then taking the top 23 most central cards. The problem is that cards which don't ultimately end up being included are still influencing the centrality scores for the cards that do. While this works fine for pools that have one major theme, it can work less well for pools with several "clusters".

`communities_build` does the following:

1. Split the on-color cards into "clusters" or "communities" using `networkx` `greedy_modular_communities`
2. Find the best community to add based on # of edges it would add / # nodes
3. Add the entire community to the pool
4. Repeat 2-3 until we have >= the target number of playables
5. Cut cards one by one based on their centrality scores until we have the target number of playables

This process makes it more likely that the relevant parts of a cluster are included together, though the exact details of the algorithm probably have room for improvement.

Other deckbuilding improvements included:

- Don't count lands towards the goal of 23 playables. This comes up if there are no more synergistic cards to include - we still prefer to add arbitrary on-color nonlands to arbitrary lands to fill out the rest of the deck.
  - Utility lands are not counted towards the # of playables, but they are counted towards the final # of edges in the build.
- If no color pair has 23 playables, we instead use the max # of playables across all the color pairs as our target for the deckbuild.