### PR TITLE
Show owned cards by pack

### DIFF
--- a/website/draft_site/drafts/templates/drafts/show_pack.html
+++ b/website/draft_site/drafts/templates/drafts/show_pack.html
@@ -22,9 +22,12 @@ View Seat:
         {% endfor %}
     </form>
 {% else %}
+    <!-- Do-nothing form to make formatting consistent with human drafter view -->
+    <form>
     {% for card, image_url in cards %}
         <img src="{{ image_url }}" width="146" height="204" />
     {% endfor %}
+    </form>
 {% endif %}
 </div>
 

--- a/website/draft_site/drafts/templates/drafts/show_pack.html
+++ b/website/draft_site/drafts/templates/drafts/show_pack.html
@@ -1,8 +1,8 @@
 View Seat:
 <!-- Human drafter is always seat 0 -->
-<a href="/draft/{{ draft_id }}">0 (You)</a>
+<a href="/draft/{{ draft.id }}">0 (You)</a>
 {% for seat in bot_seat_range %}
-    <a href="/draft/{{ draft_id }}/seat/{{ seat }}">{{ seat }}</a>
+    <a href="/draft/{{ draft.id }}/seat/{{ seat }}">{{ seat }}</a>
 {% endfor %}
 <br>
 <br>
@@ -11,7 +11,7 @@ View Seat:
 <div>
 
 {% if human_drafter %}
-    <form action="/draft/pick-card/{{ draft_id }}" method="post">
+    <form action="/draft/pick-card/{{ draft.id }}" method="post">
         {% csrf_token %}
         <input name="phase" type="hidden" value="{{ phase }}">
         <input name="pick" type="hidden" value="{{ pick }}">
@@ -28,17 +28,18 @@ View Seat:
 {% endif %}
 </div>
 
-<b>Owned Cards</b>
 {% if draft_complete %}
-<form action="/draft/{{ draft_id }}/seat/{{ current_seat }}/autobuild" method="get">
+<form action="/draft/{{ draft.id }}/seat/{{ current_seat }}/autobuild" method="get">
     <button type="submit">
         Auto-build deck
     </button>
 </form>
 {% endif %}
+<b>Owned Cards</b>
 
 <div>
-{% for card, image_url in owned_cards %}
+{% for _, image_url in owned_cards %}
+    {% if forloop.counter0|divisibleby:draft.cards_per_pack %}<br>{% endif %}
     <img src="{{ image_url }}" width="146" height="204" />
 {% endfor %}
 </div>

--- a/website/draft_site/drafts/views.py
+++ b/website/draft_site/drafts/views.py
@@ -125,7 +125,7 @@ def show_seat(request, draft_id, seat):
     owned_cards_with_images = [(c, _image_url(c.name)) for c in sorted_owned_cards]
     draft_complete = (drafter.current_phase == draft.num_phases)
 
-    context = {'cards': cards_with_images, 'draft_id': draft_id,
+    context = {'cards': cards_with_images, 'draft': draft,
                'phase': drafter.current_phase, 'pick': drafter.current_pick,
                'owned_cards': owned_cards_with_images, 'bot_seat_range': range(1, draft.num_drafters),
                'human_drafter': seat == 0, 'current_seat': seat, 'draft_complete': draft_complete}


### PR DESCRIPTION
Adds a newline between the cards in each pack for the show seat view. Makes hard to see all the cards in the pool on one page, but I think it's valuable to be able to see where a new pack starts for evaluating bot drafts. Temporarily deployed so you can see how it looks: http://ec2-54-184-81-148.us-west-2.compute.amazonaws.com:8000/draft/288

LMK if you have any alternative (simple to implement) UI suggestions.