### PR TITLE
Auto-update, display names, and fix table when unauthenticated

### DIFF
--- a/data_mining/tappedout_draft_display.user.js
+++ b/data_mining/tappedout_draft_display.user.js
@@ -1,14 +1,19 @@
 // ==UserScript==
 // @name         tappedout_draft_display
-// @version      0.1
+// @version      0.2
 // @description  Adds a visual display of the draft to the tappedout.net draft display page.
 // @author       Winter Dong
 // @match        *://tappedout.net/mtg-draft-simulator/draft/*
 // @run-at       document-end
 // @grant        none
+
+// @homepageURL  https://github.com/uponthesun/mtg-draft-ai
+// @updateURL    https://github.com/uponthesun/mtg-draft-ai/blob/tappedout-draft-display/data_mining/tappedout_draft_display.user.js
+
 // ==/UserScript==
 
-function createDisplayDivHTML(numDrafters, numPacks, cardsPerPack) {
+function createDisplayDivHTML(drafters, numPacks, cardsPerPack) {
+    const numDrafters = drafters.length
     const a = document.getElementsByTagName('a')
     const allPicks = Array.from(a).filter(x => "popover" === x.rel).map(x => x.text)
 
@@ -60,7 +65,8 @@ function createDisplayDivHTML(numDrafters, numPacks, cardsPerPack) {
     </style>`
 
     for (seat = 0; seat < numDrafters; seat++) {
-        html += `Drafter ${seat+1}\n`
+        const name = drafters[seat]
+        html += `<b>Drafter ${seat+1}: <a href="https://tappedout.net/users/${name}/">${name}</a></b>\n`
         for (var entry of drafterPickAndPacks[seat]) {
             html += `<div class="pack">`
             for (var card of entry.pack) {
@@ -79,15 +85,19 @@ function imageURL(cardName, wasPicked) {
     return `<img src="https://api.scryfall.com/cards/named?format=image&exact=${encodeURI(cardName)}" class="${cssClass}" width="146" height="204" />`
 }
 
-function getNumDrafters() {
-    const options = Array.from(document.getElementsByTagName('option'))
-    return options.map(o => o.text).filter(t => t.includes('Seat')).length / 2
+function getDrafters() {
+    const options = Array.from(document.getElementById('id_mtgo-seat').options)
+    const drafters = options.map(o => o.text).reduce(
+        (drafters, text) => text.includes('Seat') ? [...drafters, text.match(/Seat \d+: (\w+)/)[1].trim()] : drafters,
+        []
+    )
+    return drafters
 }
 
 const displayDiv = document.createElement('div')
 displayDiv.setAttribute('id', 'draftImagesDisplayDiv')
 displayDiv.setAttribute('class', 'hidden')
-displayDiv.innerHTML = createDisplayDivHTML(getNumDrafters(), 3, 15) // TODO: determine parameters from page
+displayDiv.innerHTML = createDisplayDivHTML(getDrafters(), 3, 15) // TODO: determine parameters from page
 
 const showDisplayButton = document.createElement('button')
 showDisplayButton.innerHTML = 'show/hide draft images'

--- a/data_mining/tappedout_draft_display.user.js
+++ b/data_mining/tappedout_draft_display.user.js
@@ -87,10 +87,9 @@ function imageURL(cardName, wasPicked) {
 
 function getDrafters() {
     const options = Array.from(document.getElementById('id_mtgo-seat').options)
-    const drafters = options.map(o => o.text).reduce(
-        (drafters, text) => text.includes('Seat') ? [...drafters, text.match(/Seat \d+: (\w+)/)[1].trim()] : drafters,
-        []
-    )
+    const drafters = options.map(o => o.text)
+            .filter(t => t.includes('Seat'))
+            .map(t => t.match(/Seat \d+: (\w+)/)[1].trim())
     return drafters
 }
 


### PR DESCRIPTION
Minor improvements in three parts:

1. As we make improvements to this userscript, it'd be nice to get auto-updates. Tampermonkey, for example, allows you to configure a check interval, and every time it sees a version update, it pulls the new file.
2. Instead of "Drafter 6", we'll display, e.g. "Drafter 6: uponthesun" with nice formatting (i.e. bold and with a link to the tapped out profile, much like how it's formatted in the table).
3. When you're not logged in, the first pulldown menu (allowing you to "Generate deck") doesn't display. So, instead of fetching the list of 'option' elements and dividing it by two, we'll just fetch the "Export to MTGO" pull-down by ID, which is always there.