### PR TITLE
Allow weights to change based on how far along the draft is

### DIFF
--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -1619,7 +1619,7 @@ set = "lgn"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Counters - Enabler", "Tier 2", "Elves - Enabler", "Power - Payoff",]
+tags = [ "Counters - Enabler", "Elves - Enabler", "Power - Payoff", "Tier 3",]
 set = "gtc"
 
 ["Hermit Druid"]

--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -373,7 +373,7 @@ set = "bbd"
 mana_cost = [ "1", "W",]
 color_identity = "W"
 types = [ "enchantment",]
-tags = [ "Removal", "Tier 2",]
+tags = [ "Removal", "Tier 2", "Tokens - Payoff",]
 set = "mor"
 
 ["Bound by Moonsilver"]

--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -233,14 +233,14 @@ set = "sok"
 mana_cost = [ "3", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Artifacts - Payoff", "Tier 3",]
+tags = [ "Tier 3", "Artifacts (Recursion) - Payoff",]
 set = "dom"
 
 ["Nearheath Chaplain"]
 mana_cost = [ "3", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Tier 3", "Lifegain - Enabler", "Sacrifice - Enabler", "Spirits - Enabler",]
+tags = [ "Tier 3", "Lifegain - Enabler", "Sacrifice - Enabler", "Spirit Tokens - Enabler",]
 set = "soi"
 
 ["Angel of Flight Alabaster"]
@@ -331,7 +331,7 @@ set = "dka"
 mana_cost = [ "2", "W", "W",]
 color_identity = "W"
 types = [ "sorcery",]
-tags = [ "Tokens - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Payoff", "Sacrifice - Enabler", "Tier 3",]
+tags = [ "Tokens - Enabler", "Artifacts (Creature) - Enabler", "Sacrifice - Enabler", "Tier 3",]
 set = "aer"
 
 ["Cartouche of Solidarity"]
@@ -401,7 +401,7 @@ set = "grn"
 mana_cost = [ "U",]
 color_identity = "U"
 types = [ "creature",]
-tags = [ "Ninjutsu - Enabler", "Spirits - Enabler", "Spirits - Payoff", "Tier 3",]
+tags = [ "Ninjutsu - Enabler", "Spirits - Enabler", "Spirits - Payoff", "Tier 3", "Spirit Tokens - Payoff",]
 set = "emn"
 
 [Pteramander]
@@ -450,7 +450,7 @@ set = "emn"
 mana_cost = [ "1", "U",]
 color_identity = "U"
 types = [ "creature",]
-tags = [ "Ninjutsu - Enabler", "Artifacts - Payoff", "Tier 3", "Signpost",]
+tags = [ "Ninjutsu - Enabler", "Tier 3", "Artifact Cards - Payoff",]
 set = "kld"
 
 ["Harbinger of the Tides"]
@@ -485,7 +485,7 @@ set = "soi"
 mana_cost = [ "1", "U",]
 color_identity = "U"
 types = [ "creature",]
-tags = [ "Signpost", "Spirits - Enabler", "Spirits - Payoff", "Ninjutsu - Enabler", "Tier 2",]
+tags = [ "Signpost", "Spirits - Enabler", "Spirits - Payoff", "Ninjutsu - Enabler", "Tier 2", "Spirit Tokens - Payoff",]
 set = "m19"
 
 ["Thing in the Ice"]
@@ -527,21 +527,21 @@ set = "bok"
 mana_cost = [ "2", "U",]
 color_identity = "U"
 types = [ "creature",]
-tags = [ "Spirits - Payoff", "Spirits - Enabler", "Flash - Threat", "Ninjutsu - Enabler", "Tier 3", "Signpost",]
+tags = [ "Spirits - Payoff", "Spirits - Enabler", "Flash - Threat", "Ninjutsu - Enabler", "Tier 3", "Signpost", "Spirit Tokens - Payoff",]
 set = "emn"
 
 ["Sai, Master Thopterist"]
 mana_cost = [ "2", "U",]
 color_identity = "U"
 types = [ "creature",]
-tags = [ "Artifacts - Payoff", "Signpost", "Tier 2", "Artifacts (Sac) - Payoff", "Artifacts (Sac) - Enabler", "Legends - Enabler",]
+tags = [ "Signpost", "Tier 2", "Legends - Enabler", "Artifact Cards - Payoff", "Artifacts (Creature) - Enabler",]
 set = "m19"
 
 ["Skilled Animator"]
 mana_cost = [ "2", "U",]
 color_identity = "U"
 types = [ "creature",]
-tags = [ "Artifacts (Cheap) - Payoff", "Signpost", "Tier 4",]
+tags = [ "Artifacts (Cheap) - Payoff", "Tier 4",]
 set = "m19"
 
 ["Wavebreak Hippocamp"]
@@ -625,7 +625,7 @@ set = "sok"
 mana_cost = [ "5", "U", "U",]
 color_identity = "U"
 types = [ "creature",]
-tags = [ "Spells - Payoff", "Power - Enabler", "Signpost", "Tier 4",]
+tags = [ "Spells - Payoff", "Signpost", "Tier 4",]
 set = "akh"
 
 ["Dive Down"]
@@ -996,7 +996,7 @@ set = "kld"
 mana_cost = [ "3", "B",]
 color_identity = "B"
 types = [ "creature",]
-tags = [ "Tokens - Enabler", "Graveyard - Payoff", "ETB - Enabler", "Sacrifice - Enabler", "Tier 2", "Discard - Enabler", "Discard - Payoff",]
+tags = [ "Tokens - Enabler", "Graveyard - Payoff", "ETB - Enabler", "Sacrifice - Enabler", "Tier 2", "Discard - Enabler", "Discard - Payoff", "Spirit Tokens - Enabler",]
 set = "emn"
 
 ["Sanctum Seeker"]
@@ -1185,14 +1185,14 @@ set = "bfz"
 mana_cost = [ "1",]
 color_identity = "R"
 types = [ "artifact", "creature",]
-tags = [ "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Discard - Enabler", "Hellbent - Payoff", "Tier 3",]
+tags = [ "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Discard - Enabler", "Hellbent - Payoff", "Tier 3", "Artifact Cards - Enabler",]
 set = "kld"
 
 ["Goblin Welder"]
 mana_cost = [ "R",]
 color_identity = "R"
 types = [ "creature",]
-tags = [ "Signpost", "Tier 2", "Artifacts (Sac) - Payoff", "Artifacts (Recursion) - Enabler",]
+tags = [ "Signpost", "Tier 2", "Artifacts (Recursion) - Enabler", "Artifacts (Cheap) - Payoff",]
 set = "ulg"
 
 ["Magus of the Scroll"]
@@ -1458,7 +1458,7 @@ set = "tsb"
 mana_cost = [ "2", "R",]
 color_identity = "R"
 types = [ "instant",]
-tags = [ "Tier 3", "Artifacts (Cheap) - Payoff", "Signpost",]
+tags = [ "Tier 3", "Artifacts (Cheap) - Payoff", "Spells (Red) - Enabler",]
 set = "kld"
 
 ["Wizard's Lightning"]
@@ -1521,14 +1521,14 @@ set = "emn"
 mana_cost = [ "1",]
 color_identity = "R"
 types = [ "artifact",]
-tags = [ "Removal", "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 2", "Hellbent - Enabler",]
+tags = [ "Removal", "Artifacts (Cheap) - Enabler", "Tier 2", "Hellbent - Enabler", "Artifact Cards - Enabler",]
 set = "mrd"
 
 ["Pyromancer's Goggles"]
 mana_cost = [ "5",]
 color_identity = "R"
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Spells (Red) - Payoff", "Legends - Enabler", "Tier 3",]
+tags = [ "Artifacts (Noncreature) - Enabler", "Spells (Red) - Payoff", "Tier 4", "Artifact Cards - Enabler",]
 set = "ori"
 
 ["Dragon Mantle"]
@@ -1598,7 +1598,7 @@ set = "scg"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Elves - Enabler", "Elves - Payoff", "Signpost", "Tier 4",]
+tags = [ "Elves - Enabler", "Tier 4",]
 set = "ori"
 
 ["Fa'adiyah Seer"]
@@ -1808,7 +1808,7 @@ set = "pcy"
 mana_cost = [ "3", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Elves - Enabler", "Elves - Payoff", "Signpost", "Tier 3",]
+tags = [ "Elves - Enabler", "Elves - Payoff", "Signpost", "Tier 4",]
 set = "ori"
 
 ["Territorial Allosaurus"]
@@ -1969,7 +1969,7 @@ set = "dom"
 mana_cost = [ "1", "W", "U",]
 color_identity = "UW"
 types = [ "creature",]
-tags = [ "Signpost", "Spirits - Enabler", "Spirits - Payoff", "Tier 3",]
+tags = [ "Signpost", "Spirits - Enabler", "Spirits - Payoff", "Tier 3", "Spirit Tokens - Payoff",]
 set = "dka"
 
 ["Brago, King Eternal"]
@@ -2039,7 +2039,7 @@ set = "rna"
 mana_cost = [ "2", "B", "R",]
 color_identity = "BR"
 types = [ "creature",]
-tags = [ "Signpost", "Vampires - Enabler", "Discard - Payoff", "Hellbent - Payoff", "Power - Enabler", "Tier 2",]
+tags = [ "Signpost", "Vampires - Enabler", "Discard - Payoff", "Hellbent - Payoff", "Tier 2",]
 set = "emn"
 
 ["Skarrg Guildmage"]
@@ -2137,7 +2137,7 @@ set = "ogw"
 mana_cost = [ "B",]
 color_identity = "BG"
 types = [ "creature",]
-tags = [ "Tier 3", "Elves - Enabler", "Elves - Payoff", "Signpost",]
+tags = [ "Elves - Enabler", "Elves - Payoff", "Tier 4",]
 set = "ori"
 
 ["Glowspore Shaman"]
@@ -2172,7 +2172,7 @@ set = "grn"
 mana_cost = [ "3", "B", "G",]
 color_identity = "BG"
 types = [ "creature",]
-tags = [ "Graveyard - Payoff", "Land Graveyard - Enabler", "Land Graveyard - Payoff", "Tier 2", "Land Dying - Enabler", "Land Extra - Payoff", "Legends - Enabler", "Discard - Payoff", "Power - Enabler",]
+tags = [ "Graveyard - Payoff", "Land Graveyard - Enabler", "Land Graveyard - Payoff", "Tier 2", "Land Dying - Enabler", "Land Extra - Payoff", "Legends - Enabler", "Discard - Payoff",]
 set = "soi"
 
 ["River Hoopoe"]
@@ -2228,14 +2228,14 @@ set = "dds"
 mana_cost = [ "2", "U", "R",]
 color_identity = "RU"
 types = [ "creature",]
-tags = [ "Artifacts - Payoff", "Signpost", "Tier 4",]
+tags = [ "Tier 4", "Artifacts (Cheap) - Enabler",]
 set = "ori"
 
 ["Maverick Thopterist"]
 mana_cost = [ "3", "U", "R",]
 color_identity = "RU"
 types = [ "creature",]
-tags = [ "Signpost", "Tokens - Enabler", "Artifacts - Enabler", "ETB - Enabler", "Artifacts (Creature) - Enabler", "Tier 2", "Artifacts (Cheap) - Payoff", "Artifacts (Sac) - Enabler",]
+tags = [ "Signpost", "Tokens - Enabler", "ETB - Enabler", "Artifacts (Creature) - Enabler", "Tier 2", "Artifacts (Cheap) - Payoff", "Artifacts (Cheap) - Enabler",]
 set = "aer"
 
 ["Martial Glory"]
@@ -2284,105 +2284,105 @@ set = "ktk"
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Counters - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 2", "Tokens Aggro - Payoff", "Wizards - Enabler", "Elves - Payoff", "Spirits - Payoff", "Vampires - Payoff",]
+tags = [ "Counters - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 2", "Tokens Aggro - Payoff", "Wizards - Enabler", "Elves - Payoff", "Spirits - Payoff", "Vampires - Payoff", "Artifact Cards - Enabler", "Spirit Tokens - Payoff",]
 set = "aer"
 
 ["Perilous Myr"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Removal", "Sacrifice - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifacts (Sac) - Enabler",]
+tags = [ "Removal", "Sacrifice - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifact Cards - Enabler",]
 set = "som"
 
 ["Phyrexian Revoker"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Tier 3", "Artifacts (Cheap) - Enabler", "Artifacts (Creature) - Enabler", "Artifacts - Enabler",]
+tags = [ "Tier 3", "Artifacts (Cheap) - Enabler", "Artifacts (Creature) - Enabler", "Artifact Cards - Enabler",]
 set = "m15"
 
 ["Steel Overseer"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Signpost", "Counters - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Payoff", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 1", "Artifacts (Recursion) - Payoff",]
+tags = [ "Signpost", "Counters - Enabler", "Artifacts (Creature) - Payoff", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 1", "Artifacts (Recursion) - Payoff", "Artifact Cards - Enabler",]
 set = "m11"
 
 ["Filigree Familiar"]
 mana_cost = [ "3",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Lifegain - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifacts (Sac) - Enabler",]
+tags = [ "Lifegain - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifact Cards - Enabler",]
 set = "kld"
 
 ["Palladium Myr"]
 mana_cost = [ "3",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 2", "Ramp - Enabler",]
+tags = [ "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 2", "Ramp - Enabler", "Artifact Cards - Enabler",]
 set = "c14"
 
 [Skyscanner]
 mana_cost = [ "3",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Ninjutsu - Enabler", "ETB - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifacts (Sac) - Enabler",]
+tags = [ "Ninjutsu - Enabler", "ETB - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifact Cards - Enabler",]
 set = "m19"
 
 ["Mindless Automaton"]
 mana_cost = [ "4",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Counters - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Tier 2", "Artifacts (Recursion) - Payoff", "Discard - Enabler", "Hellbent - Enabler",]
+tags = [ "Counters - Enabler", "Artifacts (Creature) - Enabler", "Tier 2", "Artifacts (Recursion) - Payoff", "Discard - Enabler", "Hellbent - Enabler", "Artifact Cards - Enabler",]
 set = "tsb"
 
 ["Karn, Silver Golem"]
 mana_cost = [ "5",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Signpost", "Artifacts - Enabler", "Artifacts (Noncreature) - Payoff", "Artifacts (Creature) - Enabler", "Tier 3", "Legends - Enabler",]
+tags = [ "Signpost", "Artifacts (Noncreature) - Payoff", "Artifacts (Creature) - Enabler", "Tier 3", "Legends - Enabler", "Artifact Cards - Enabler",]
 set = "usg"
 
 ["Thopter Squadron"]
 mana_cost = [ "5",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Tokens - Enabler", "Counters - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Tier 2", "Artifacts (Sac) - Enabler", "Artifacts (Recursion) - Payoff", "Counters Target - Payoff",]
+tags = [ "Tokens - Enabler", "Counters - Enabler", "Artifacts (Creature) - Enabler", "Tier 2", "Artifacts (Recursion) - Payoff", "Counters Target - Payoff", "Artifact Cards - Enabler", "Artifacts (Cheap) - Enabler",]
 set = "exo"
 
 ["Metalwork Colossus"]
 mana_cost = [ "1", "1",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Signpost", "Artifacts - Enabler", "Artifacts (Noncreature) - Payoff", "Tier 3", "Artifacts (Recursion) - Payoff",]
+tags = [ "Signpost", "Artifacts (Noncreature) - Payoff", "Artifact Cards - Enabler", "Tier 4",]
 set = "kld"
 
 ["Bag of Holding"]
 mana_cost = [ "1",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Tier 3", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts - Enabler", "Drake Haven - Enabler", "Discard - Payoff",]
+tags = [ "Tier 3", "Artifacts (Cheap) - Enabler", "Drake Haven - Enabler", "Discard - Payoff", "Artifact Cards - Enabler",]
 set = "m20"
 
 ["Blade of the Bloodchief"]
 mana_cost = [ "1",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Counters - Enabler", "Vampires - Payoff", "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3", "Sacrifice Outlet - Payoff", "Counters Target - Enabler",]
+tags = [ "Counters - Enabler", "Vampires - Payoff", "Artifacts (Cheap) - Enabler", "Sacrifice Outlet - Payoff", "Counters Target - Enabler", "Tier 4", "Artifact Cards - Enabler",]
 set = "zen"
 
 ["Brittle Effigy"]
 mana_cost = [ "1",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Removal", "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 3",]
+tags = [ "Removal", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifact Cards - Enabler", "Flash - Interaction",]
 set = "m11"
 
 [O-Naginata]
 mana_cost = [ "1",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Power - Payoff", "Artifacts (Cheap) - Enabler", "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Tier 3",]
+tags = [ "Power - Payoff", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifact Cards - Enabler",]
 set = "sok"
 
 ["The Ozolith"]
@@ -2396,133 +2396,133 @@ set = "iko"
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "dis"
 
 ["Boros Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "rav"
 
 ["Culling Dais"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Tier 4", "Sacrifice - Payoff", "Sacrifice Outlet - Enabler", "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler",]
+tags = [ "Tier 4", "Sacrifice - Payoff", "Sacrifice Outlet - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Artifact Cards - Enabler",]
 set = "bbd"
 
 ["Dimir Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "rav"
 
 ["Golgari Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "rav"
 
 ["Gruul Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "gpt"
 
 ["Ichor Wellspring"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Tier 4", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Sac) - Enabler",]
+tags = [ "Tier 4", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Artifact Cards - Enabler",]
 set = "mbs"
 
 ["Idol of Oblivion"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Tier 2", "Tokens - Payoff", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts - Enabler", "Artifacts (Recursion) - Payoff",]
+tags = [ "Tier 2", "Tokens - Payoff", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Artifact Cards - Enabler",]
 set = "c19"
 
 ["Izzet Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "gpt"
 
 ["Key to the City"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Ninjutsu - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 2", "Discard - Enabler", "Hellbent - Enabler", "Power - Payoff",]
+tags = [ "Ninjutsu - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Cheap) - Enabler", "Tier 2", "Discard - Enabler", "Hellbent - Enabler", "Power - Payoff", "Artifact Cards - Enabler",]
 set = "kld"
 
 ["Orzhov Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "gpt"
 
 ["Rakdos Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "dis"
 
 ["Selesnya Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "rav"
 
 ["Simic Signet"]
 mana_cost = [ "2",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3",]
+tags = [ "Artifacts (Cheap) - Enabler", "Artifacts (Noncreature) - Enabler", "Ramp - Enabler", "Fixer", "Tier 3", "Artifact Cards - Enabler",]
 set = "dis"
 
 ["Mindstorm Crown"]
 mana_cost = [ "3",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Cheap) - Enabler", "Hellbent - Payoff", "Tier 4", "Signpost",]
+tags = [ "Artifacts (Noncreature) - Enabler", "Hellbent - Payoff", "Tier 4", "Signpost", "Artifact Cards - Enabler",]
 set = "mrd"
 
 ["Piston Sledge"]
 mana_cost = [ "3",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Cheap) - Enabler", "Artifacts (Sac) - Payoff", "Signpost", "Tier 3",]
+tags = [ "Artifacts (Noncreature) - Enabler", "Signpost", "Tier 3", "Artifact Cards - Enabler", "Artifacts (Cheap) - Payoff",]
 set = "mbs"
 
 ["Hedron Archive"]
 mana_cost = [ "4",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Tier 2", "Ramp - Enabler", "Artifacts (Recursion) - Payoff",]
+tags = [ "Artifacts (Noncreature) - Enabler", "Tier 2", "Ramp - Enabler", "Artifacts (Recursion) - Payoff", "Artifact Cards - Enabler",]
 set = "bfz"
 
 [Panharmonicon]
 mana_cost = [ "4",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Signpost", "ETB - Payoff", "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Tier 4",]
+tags = [ "Signpost", "ETB - Payoff", "Artifacts (Noncreature) - Enabler", "Tier 4", "Artifact Cards - Enabler",]
 set = "kld"
 
 [Weatherlight]
 mana_cost = [ "4",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Signpost", "Artifacts - Payoff", "Artifacts - Enabler", "Artifacts (Noncreature) - Enabler", "Artifacts (Creature) - Enabler", "Tier 1", "Artifacts (Recursion) - Payoff", "Legends - Payoff", "Legends - Enabler",]
+tags = [ "Signpost", "Artifacts (Noncreature) - Enabler", "Artifacts (Creature) - Enabler", "Tier 1", "Artifacts (Recursion) - Payoff", "Legends - Payoff", "Legends - Enabler", "Artifact Cards - Enabler", "Artifact Cards - Payoff",]
 set = "dom"
 
 ["Adarkar Wastes"]
@@ -2557,7 +2557,7 @@ set = "ogw"
 mana_cost = []
 color_identity = "UW"
 types = [ "land",]
-tags = [ "Spirits - Enabler", "Tier 3",]
+tags = [ "Tier 3", "Spirit Tokens - Enabler",]
 set = "isd"
 
 ["Drowned Catacomb"]
@@ -2823,7 +2823,7 @@ set = "m12"
 mana_cost = []
 color_identity = ""
 types = [ "land",]
-tags = [ "Tokens - Enabler", "Land Graveyard - Enabler", "Artifacts - Enabler", "Artifacts (Creature) - Enabler", "Land Dying - Enabler", "Tier 3",]
+tags = [ "Tokens - Enabler", "Land Graveyard - Enabler", "Artifacts (Creature) - Enabler", "Land Dying - Enabler", "Tier 3",]
 set = "ori"
 
 ["Memorial to Unity"]

--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -79,7 +79,7 @@ set = "thb"
 mana_cost = [ "1", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Spirits - Enabler", "Tier 3",]
+tags = [ "Spirits - Enabler", "Tier 4",]
 set = "chk"
 
 ["Lone Rider"]
@@ -135,14 +135,14 @@ set = "bok"
 mana_cost = [ "W", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Tier 4", "Heroic - Payoff",]
+tags = [ "Heroic - Payoff", "Tier 3",]
 set = "bng"
 
 ["Angel of Vitality"]
 mana_cost = [ "2", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Tier 3", "Lifegain - Payoff", "Signpost",]
+tags = [ "Lifegain - Payoff", "Signpost", "Tier 4",]
 set = "m20"
 
 ["Attended Knight"]
@@ -191,7 +191,7 @@ set = "mh1"
 mana_cost = [ "2", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Lifegain - Enabler", "Signpost", "Vampires - Enabler", "Vampires - Payoff", "Tier 3", "Legends - Enabler",]
+tags = [ "Lifegain - Enabler", "Signpost", "Vampires - Enabler", "Vampires - Payoff", "Legends - Enabler", "Tier 4",]
 set = "xln"
 
 ["Militia Bugler"]
@@ -366,7 +366,7 @@ set = "dom"
 mana_cost = [ "W", "W",]
 color_identity = "W"
 types = [ "enchantment",]
-tags = [ "Counters - Enabler", "Counters - Payoff", "ETB - Payoff", "Signpost", "Counters Target - Enabler", "Tier 2",]
+tags = [ "Counters - Enabler", "Counters - Payoff", "ETB - Payoff", "Signpost", "Counters Target - Enabler", "Tier 1",]
 set = "bbd"
 
 ["Weight of Conscience"]
@@ -814,7 +814,7 @@ set = "grn"
 mana_cost = [ "B",]
 color_identity = "B"
 types = [ "creature",]
-tags = [ "Graveyard - Enabler", "Tier 3",]
+tags = [ "Graveyard - Enabler", "Tier 4",]
 set = "m19"
 
 ["Asylum Visitor"]
@@ -954,7 +954,7 @@ set = "xln"
 mana_cost = [ "2", "B",]
 color_identity = "B"
 types = [ "creature",]
-tags = [ "Tier 3", "Vampires - Enabler", "Ninjas - Payoff", "Ninjas - Enabler", "Signpost",]
+tags = [ "Vampires - Enabler", "Ninjas - Payoff", "Ninjas - Enabler", "Tier 4",]
 set = "mh1"
 
 ["Vampire Nighthawk"]
@@ -1136,7 +1136,7 @@ set = "soi"
 mana_cost = [ "1", "B",]
 color_identity = "B"
 types = [ "sorcery",]
-tags = [ "Tier 3", "Graveyard - Enabler", "Spells - Enabler",]
+tags = [ "Tier 3", "Graveyard - Enabler",]
 set = "mh1"
 
 ["Return from Extinction"]
@@ -1178,7 +1178,7 @@ set = "soi"
 mana_cost = [ "B",]
 color_identity = "B"
 types = [ "enchantment",]
-tags = [ "Lifegain - Enabler", "Sacrifice - Payoff", "Tier 2", "Signpost", "Sacrifice Outlet - Enabler",]
+tags = [ "Lifegain - Enabler", "Sacrifice - Payoff", "Signpost", "Sacrifice Outlet - Enabler", "Tier 3",]
 set = "bfz"
 
 ["Bomat Courier"]
@@ -1248,7 +1248,7 @@ set = "soi"
 mana_cost = [ "1", "R",]
 color_identity = "R"
 types = [ "creature",]
-tags = [ "Tier 3", "Sacrifice - Enabler",]
+tags = [ "Sacrifice - Enabler", "Tier 4",]
 set = "rna"
 
 ["Young Pyromancer"]
@@ -1346,7 +1346,7 @@ set = "hou"
 mana_cost = [ "4", "R", "R",]
 color_identity = "R"
 types = [ "creature",]
-tags = [ "Tier 3", "Signpost", "Land Extra - Payoff",]
+tags = [ "Signpost", "Land Extra - Payoff", "Tier 4", "Ramp - Payoff",]
 set = "bfz"
 
 ["Igneous Elemental"]
@@ -1367,7 +1367,7 @@ set = "emn"
 mana_cost = [ "5", "R", "R", "R",]
 color_identity = "R"
 types = [ "creature",]
-tags = [ "Tier 3", "Ramp - Payoff", "Goreclaw - Payoff",]
+tags = [ "Ramp - Payoff", "Goreclaw - Payoff", "Tier 4",]
 set = "bbd"
 
 ["Fall of the Titans"]
@@ -1612,7 +1612,7 @@ set = "plc"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Elves - Enabler", "Elves - Payoff", "Trick", "Signpost", "Tier 2",]
+tags = [ "Elves - Enabler", "Elves - Payoff", "Trick", "Signpost", "Tier 3",]
 set = "lgn"
 
 ["Gyre Sage"]
@@ -1647,7 +1647,7 @@ set = "mh1"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Power - Payoff", "Tier 3", "Signpost",]
+tags = [ "Power - Payoff", "Tier 4",]
 set = "thb"
 
 ["Satyr Wayfinder"]
@@ -1675,7 +1675,7 @@ set = "m12"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Tier 3", "Tokens - Payoff", "Signpost", "Elves - Enabler", "Tokens Aggro - Payoff",]
+tags = [ "Tokens - Payoff", "Signpost", "Elves - Enabler", "Tokens Aggro - Payoff", "Tier 4",]
 set = "m20"
 
 ["Abzan Beastmaster"]
@@ -1780,7 +1780,7 @@ set = "ori"
 mana_cost = [ "3", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Power - Enabler", "Power - Payoff", "Legends - Enabler", "Signpost", "Goreclaw - Enabler", "Tier 1",]
+tags = [ "Power - Enabler", "Power - Payoff", "Legends - Enabler", "Signpost", "Goreclaw - Enabler", "Tier 2",]
 set = "m19"
 
 ["Oracle of Mul Daya"]
@@ -1857,7 +1857,7 @@ set = "bfz"
 mana_cost = [ "7", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Signpost", "Graveyard - Payoff", "Tier 3", "Power - Enabler",]
+tags = [ "Signpost", "Graveyard - Payoff", "Power - Enabler", "Tier 4",]
 set = "dka"
 
 ["Sifter Wurm"]
@@ -1878,7 +1878,7 @@ set = "kld"
 mana_cost = [ "3", "G", "G",]
 color_identity = "G"
 types = [ "instant",]
-tags = [ "Tokens - Enabler", "Tier 3", "Tokens - Payoff",]
+tags = [ "Tokens - Enabler", "Tokens - Payoff", "Tier 4",]
 set = "rav"
 
 ["Prey Upon"]
@@ -2004,7 +2004,7 @@ set = "c18"
 mana_cost = [ "3", "U", "B",]
 color_identity = "BU"
 types = [ "creature",]
-tags = [ "ETB - Enabler", "Tier 2",]
+tags = [ "ETB - Enabler", "Tier 3",]
 set = "ori"
 
 ["Dinrova Horror"]
@@ -2200,7 +2200,7 @@ set = "akh"
 mana_cost = [ "1", "G", "U", "U",]
 color_identity = "GU"
 types = [ "creature",]
-tags = [ "Signpost", "Flash - Interaction", "Tier 2",]
+tags = [ "Signpost", "Flash - Interaction", "Tier 3",]
 set = "c15"
 
 ["Prophet of Kruphix"]
@@ -2270,7 +2270,7 @@ set = "ths"
 mana_cost = [ "1", "R", "W",]
 color_identity = "WR"
 types = [ "enchantment", "creature",]
-tags = [ "Tier 3", "Heroic - Payoff", "Tokens Aggro - Enabler", "Signpost",]
+tags = [ "Heroic - Payoff", "Tokens Aggro - Enabler", "Signpost", "Tokens Aggro - Payoff", "Tier 3",]
 set = "thb"
 
 ["Jeskai Ascendancy"]
@@ -2333,7 +2333,7 @@ set = "m19"
 mana_cost = [ "4",]
 color_identity = ""
 types = [ "artifact", "creature",]
-tags = [ "Counters - Enabler", "Artifacts (Creature) - Enabler", "Tier 2", "Artifacts (Recursion) - Payoff", "Discard - Enabler", "Hellbent - Enabler", "Artifact Cards - Enabler",]
+tags = [ "Counters - Enabler", "Artifacts (Creature) - Enabler", "Artifacts (Recursion) - Payoff", "Discard - Enabler", "Hellbent - Enabler", "Artifact Cards - Enabler", "Tier 3",]
 set = "tsb"
 
 ["Karn, Silver Golem"]

--- a/cube_81183_tag_data.toml
+++ b/cube_81183_tag_data.toml
@@ -149,7 +149,7 @@ set = "m20"
 mana_cost = [ "2", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Tier 3", "Tokens - Enabler", "Tokens Aggro - Enabler", "Sacrifice - Enabler",]
+tags = [ "Tier 3", "Tokens - Enabler", "Tokens Aggro - Enabler",]
 set = "mm3"
 
 ["Deadeye Harpooner"]
@@ -240,7 +240,7 @@ set = "dom"
 mana_cost = [ "3", "W",]
 color_identity = "W"
 types = [ "creature",]
-tags = [ "Tier 3", "Lifegain - Enabler", "Sacrifice - Enabler", "Spirit Tokens - Enabler",]
+tags = [ "Tier 3", "Lifegain - Enabler", "Spirit Tokens - Enabler",]
 set = "soi"
 
 ["Angel of Flight Alabaster"]
@@ -331,7 +331,7 @@ set = "dka"
 mana_cost = [ "2", "W", "W",]
 color_identity = "W"
 types = [ "sorcery",]
-tags = [ "Tokens - Enabler", "Artifacts (Creature) - Enabler", "Sacrifice - Enabler", "Tier 3",]
+tags = [ "Tokens - Enabler", "Artifacts (Creature) - Enabler", "Tier 3", "Tokens Aggro - Enabler",]
 set = "aer"
 
 ["Cartouche of Solidarity"]
@@ -800,7 +800,7 @@ set = "ktk"
 mana_cost = [ "B",]
 color_identity = "B"
 types = [ "creature",]
-tags = [ "Sacrifice - Payoff", "Lifegain - Enabler", "Counters - Enabler", "Vampires - Enabler", "Vampires - Payoff", "Signpost", "Tier 3", "Sacrifice Outlet - Enabler",]
+tags = [ "Lifegain - Enabler", "Counters - Enabler", "Vampires - Enabler", "Vampires - Payoff", "Signpost", "Tier 3", "Sacrifice Outlet - Enabler", "Sacrifice - Payoff",]
 set = "soi"
 
 ["Pilfering Imp"]
@@ -1311,7 +1311,7 @@ set = "emn"
 mana_cost = [ "2", "R",]
 color_identity = "R"
 types = [ "creature",]
-tags = [ "Sacrifice - Enabler", "Tier 3", "Legends - Enabler",]
+tags = [ "Sacrifice - Enabler", "Tier 3", "Legends - Enabler", "Sacrifice Outlet - Payoff",]
 set = "roe"
 
 ["Avaricious Dragon"]
@@ -1402,7 +1402,7 @@ set = "ths"
 mana_cost = [ "1", "R",]
 color_identity = "R"
 types = [ "instant",]
-tags = [ "Tier 3", "Removal", "Heroic - Enabler", "Spells (Red) - Enabler", "Spells - Enabler",]
+tags = [ "Removal", "Heroic - Enabler", "Spells (Red) - Enabler", "Spells - Enabler", "Tier 2",]
 set = "bng"
 
 ["Fiery Conclusion"]
@@ -1416,7 +1416,7 @@ set = "rav"
 mana_cost = [ "1", "R",]
 color_identity = "R"
 types = [ "instant",]
-tags = [ "Heroic - Enabler", "Spells - Enabler", "Trick", "Spells (Red) - Enabler", "Power - Payoff", "Tier 4",]
+tags = [ "Heroic - Enabler", "Spells - Enabler", "Trick", "Spells (Red) - Enabler", "Power - Payoff", "Tier 3",]
 set = "mh1"
 
 ["Harvest Pyre"]
@@ -1430,14 +1430,14 @@ set = "isd"
 mana_cost = [ "1", "R",]
 color_identity = "R"
 types = [ "instant",]
-tags = [ "Trick", "Heroic - Enabler", "Power - Payoff", "Spells - Enabler", "Tier 4",]
+tags = [ "Trick", "Heroic - Enabler", "Power - Payoff", "Tier 3",]
 set = "aer"
 
 ["Temur Battle Rage"]
 mana_cost = [ "1", "R",]
 color_identity = "R"
 types = [ "instant",]
-tags = [ "Trick", "Heroic - Enabler", "Spells - Enabler", "Power - Payoff", "Tier 4",]
+tags = [ "Trick", "Heroic - Enabler", "Power - Payoff", "Tier 4",]
 set = "frf"
 
 ["Brimstone Volley"]
@@ -1486,7 +1486,7 @@ set = "ori"
 mana_cost = [ "R",]
 color_identity = "R"
 types = [ "sorcery",]
-tags = [ "Tier 4", "Spells - Enabler", "Heroic - Enabler",]
+tags = [ "Spells - Enabler", "Heroic - Enabler", "Tier 3",]
 set = "kld"
 
 ["Avacyn's Judgment"]
@@ -1640,7 +1640,7 @@ set = "rna"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Graveyard - Payoff", "Tokens - Enabler", "Tier 3", "Sacrifice - Enabler",]
+tags = [ "Graveyard - Payoff", "Tokens - Enabler", "Tier 3",]
 set = "mh1"
 
 ["Nessian Hornbeetle"]
@@ -1661,7 +1661,7 @@ set = "bng"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "creature",]
-tags = [ "Counters - Enabler", "Tier 3", "Counters Target - Enabler",]
+tags = [ "Counters - Enabler", "Counters Target - Enabler", "Tier 4",]
 set = "aer"
 
 [Skinshifter]
@@ -1920,7 +1920,7 @@ set = "som"
 mana_cost = [ "3", "G",]
 color_identity = "G"
 types = [ "tribal", "sorcery",]
-tags = [ "Elves - Enabler", "Tier 2", "Spells - Enabler", "Trick", "Tokens Aggro - Enabler", "Tokens - Enabler", "Big Counters - Enabler", "Counters Target - Enabler", "Sacrifice - Enabler",]
+tags = [ "Elves - Enabler", "Tier 2", "Spells - Enabler", "Trick", "Tokens - Enabler", "Big Counters - Enabler", "Counters Target - Enabler", "Sacrifice - Enabler",]
 set = "mor"
 
 ["Nissa's Judgment"]
@@ -1948,7 +1948,7 @@ set = "soi"
 mana_cost = [ "1", "G",]
 color_identity = "G"
 types = [ "enchantment",]
-tags = [ "Tokens - Enabler", "Heroic - Enabler", "Tier 3", "Sacrifice - Enabler", "Tokens Aggro - Enabler", "Power - Payoff",]
+tags = [ "Tokens - Enabler", "Heroic - Enabler", "Tier 3", "Power - Payoff",]
 set = "rav"
 
 ["Path of Discovery"]
@@ -2375,7 +2375,7 @@ set = "zen"
 mana_cost = [ "1",]
 color_identity = ""
 types = [ "artifact",]
-tags = [ "Removal", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifact Cards - Enabler", "Flash - Interaction",]
+tags = [ "Removal", "Artifacts (Cheap) - Enabler", "Tier 3", "Artifact Cards - Enabler", "Flash - Interaction", "Hellbent - Enabler",]
 set = "m11"
 
 [O-Naginata]

--- a/mtg_draft_ai/brains.py
+++ b/mtg_draft_ai/brains.py
@@ -56,10 +56,31 @@ class RatedCard:
         self.rating = rating
 
 
+class ConstantWeight:
+
+    def __init__(self, weight):
+        self.weight = weight
+
+    def compute(self, cards_owned, draft_info):
+        return self.weight
+
+
+class LinearProgressWeight:
+
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def compute(self, cards_owned, draft_info):
+        progress = len(cards_owned) / (draft_info.num_phases * draft_info.cards_per_pack)
+
+        return self.start + progress * (self.end - self.start)
+
+
 class ComponentRater(abc.ABC):
     """Defines interface for a Rater for a specific component such as power delta, synergy delta, etc."""
 
-    def __init__(self, weight=1):
+    def __init__(self, weight=ConstantWeight(1)):
         """
         Args:
             weight (float): Weight of this component when calculating the final rating.
@@ -103,7 +124,7 @@ class TwoColorComboRatingsPicker(Picker):
     def ratings(self, pack, cards_owned, draft_info):
         cards_with_rating_components = self._raw_rating_components(pack, cards_owned, draft_info)
         cards_with_normalized_rating_components = self._normalized_ratings(cards_with_rating_components, cards_owned)
-        rated_cards = self._final_ratings(cards_with_normalized_rating_components)
+        rated_cards = self._final_ratings(cards_with_normalized_rating_components, cards_owned, draft_info)
         sorted_rated_cards = sorted(rated_cards, key=lambda rc: rc.rating, reverse=True)
 
         return sorted_rated_cards
@@ -134,12 +155,13 @@ class TwoColorComboRatingsPicker(Picker):
 
         return normalized_ratings
 
-    def _final_ratings(self, cards_with_normalized_rating_components):
+    def _final_ratings(self, cards_with_normalized_rating_components, cards_owned, draft_info):
         final_ratings = [copy.copy(r) for r in cards_with_normalized_rating_components]
 
-        denominator = sum(cr.weight for cr in self.component_raters)
+        denominator = sum(cr.weight.compute(cards_owned, draft_info) for cr in self.component_raters)
         for card_to_rate in final_ratings:
-            numerator = sum(cr.weight * card_to_rate.components[cr.name()] for cr in self.component_raters)
+            numerator = sum(cr.weight.compute(cards_owned, draft_info) * card_to_rate.components[cr.name()]
+                            for cr in self.component_raters)
             card_to_rate.rating = round(numerator / denominator, self.ROUND_NUM_DIGITS)
 
         return final_ratings
@@ -216,7 +238,7 @@ class CommonNeighborsRater(ComponentRater):
     especially helps for early picks when you don't have many cards yet.
     """
 
-    def __init__(self, common_neighbors, weight=1):
+    def __init__(self, common_neighbors, weight=ConstantWeight(1)):
         super().__init__(weight=weight)
         self.common_neighbors = common_neighbors
 
@@ -268,10 +290,10 @@ class FixingLandsRater(ComponentRater):
 
         # Hand-tuned lower bound, no strong theoretical justification, but supported by intuition
         # that improving your mana always has value
-        lower_bound = 0.2
+        lower_bound = 0.3
         # Hand-tuned / arbitrary starting offset, which makes it rate fixers lower initially and higher later on.
         # Having more fixers already increases the offset which decreases the rating.
-        offset = 4 + num_oncolor_fixer_lands
+        offset = 3 + num_oncolor_fixer_lands
         oncolor_nonlands_proportion_with_offset = max(0, (num_oncolor_nonlands - offset)) / num_picks_made
 
         return lower_bound + (1 - lower_bound) * oncolor_nonlands_proportion_with_offset
@@ -291,13 +313,13 @@ class SynergyPowerFixingPicker(TwoColorComboRatingsPicker):
     def __init__(self, common_neighbors):
         component_raters = [
             CardsOwnedPowerRater(),
-            PowerDeltaRater(weight=2),
+            PowerDeltaRater(weight=LinearProgressWeight(start=2, end=1)),
             CardsOwnedSynergyRater(),
             SynergyDeltaRater(),
-            CommonNeighborsRater(common_neighbors=common_neighbors),
+            CommonNeighborsRater(common_neighbors=common_neighbors, weight=LinearProgressWeight(start=1.5, end=0.5)),
             # Weight is equal to sum of weights for power delta + synergy delta + common neighbors,
             # which are generally all 0 for fixing lands.
-            FixingLandsRater(weight=4)
+            FixingLandsRater(weight=ConstantWeight(3))
         ]
         super().__init__(component_raters)
 

--- a/mtg_draft_ai/brains.py
+++ b/mtg_draft_ai/brains.py
@@ -312,14 +312,14 @@ class SynergyPowerFixingPicker(TwoColorComboRatingsPicker):
 
     def __init__(self, common_neighbors):
         component_raters = [
-            CardsOwnedPowerRater(),
+            CardsOwnedPowerRater(weight=LinearProgressWeight(start=1, end=2)),
             PowerDeltaRater(weight=LinearProgressWeight(start=2, end=1)),
-            CardsOwnedSynergyRater(),
-            SynergyDeltaRater(),
-            CommonNeighborsRater(common_neighbors=common_neighbors, weight=LinearProgressWeight(start=1.5, end=0.5)),
+            CardsOwnedSynergyRater(weight=LinearProgressWeight(start=1, end=2)),
+            SynergyDeltaRater(weight=LinearProgressWeight(start=1, end=2)),
+            CommonNeighborsRater(common_neighbors=common_neighbors, weight=LinearProgressWeight(start=2, end=1)),
             # Weight is equal to sum of weights for power delta + synergy delta + common neighbors,
             # which are generally all 0 for fixing lands.
-            FixingLandsRater(weight=ConstantWeight(3))
+            FixingLandsRater(weight=ConstantWeight(5))
         ]
         super().__init__(component_raters)
 

--- a/tests/unit/test_picker.py
+++ b/tests/unit/test_picker.py
@@ -18,7 +18,7 @@ CARDS_BY_NAME = {c.name: c for c in CUBE_LIST}
 
 @pytest.fixture
 def draft_info():
-    return mock.Mock(name='draft_info')
+    return mock.Mock(name='draft_info', num_phases=3, cards_per_pack=15)
 
 
 @pytest.fixture

--- a/trials.py
+++ b/trials.py
@@ -20,7 +20,7 @@ def main():
     args = parser.parse_args()
 
     cube_list = read_cube_toml(args.card_data, args.fixer_data)
-    draft_info = DraftInfo(card_list=cube_list, num_drafters=6, num_phases=3, cards_per_pack=15)
+    draft_info = DraftInfo(card_list=cube_list, num_drafters=8, num_phases=3, cards_per_pack=15)
     drafter_factory = SynergyPowerFixingPicker.factory(cube_list)
 
     deck_metrics = []
@@ -102,11 +102,18 @@ def decks_to_html(decks):
         deck_graph = synergy.create_graph(deck, remove_isolated=False)
         sorted_deck = [tup[0] for tup in synergy.sorted_centralities(deck_graph)]
 
-        html += 'Deck {} - # Edges: {} \n'.format(i, len(deck_graph.edges))
+        html += 'Deck {} - {} - # Edges: {} \n'.format(i, ''.join(deck_colors(sorted_deck)), len(deck_graph.edges))
         html += '<div>\n{}</div>\n'.format(display.cards_to_html(sorted_deck))
         i += 1
 
     return html
+
+def deck_colors(deck):
+    result = set()
+    for card in deck:
+        for color in card.color_id:
+            result.add(color)
+    return sorted(list(result))
 
 
 if __name__ == '__main__':

--- a/trials.py
+++ b/trials.py
@@ -102,18 +102,23 @@ def decks_to_html(decks):
         deck_graph = synergy.create_graph(deck, remove_isolated=False)
         sorted_deck = [tup[0] for tup in synergy.sorted_centralities(deck_graph)]
 
-        html += 'Deck {} - {} - # Edges: {} \n'.format(i, ''.join(deck_colors(sorted_deck)), len(deck_graph.edges))
+        html += 'Deck {} - {} - # Edges: {} \n'.format(i, deck_colors(sorted_deck), len(deck_graph.edges))
         html += '<div>\n{}</div>\n'.format(display.cards_to_html(sorted_deck))
         i += 1
 
     return html
 
+
 def deck_colors(deck):
-    result = set()
-    for card in deck:
+    nonlands = [c for c in deck if 'land' not in c.types]
+    counts = {}
+    for card in nonlands:
         for color in card.color_id:
-            result.add(color)
-    return sorted(list(result))
+            if color not in counts:
+                counts[color] = 0
+            counts[color] += 1
+    sorted_by_count = [k for k, v in sorted(counts.items(), key=lambda i: i[1], reverse=True)]
+    return ''.join(sorted(c if counts[c] > 3 else c.lower() for c in sorted_by_count))  # splash colors are lowercase
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change follows the idea that early in the draft you want to bias more towards being flexible and taking the "generally best" cards, but later in the draft you want to take the cards best for the cards you already have.

Instead of all weights having to be constant for each component, now we can specify a start and end weight for a component, and the value of the weight will linearly move between those two points based on how far along the draft is.

(Components can also still use constant weights.)