### PR TITLE
Include set names in export to deckbuild UI

### DIFF
--- a/website/draft_site/drafts/templates/drafts/auto_build.html
+++ b/website/draft_site/drafts/templates/drafts/auto_build.html
@@ -21,8 +21,8 @@ Average card power: {{ avg_power }}
 </div>
 
 <textarea rows="{{ textarea_rows }}">
-{% for name in deck_card_names %}1 {{ name }}
+{% for name, set in deck_card_names %}1 {{ name }} ({{ set|upper }})
 {% endfor %}
-{% for name in leftovers_card_names %}1 {{ name }}
+{% for name, set in leftovers_card_names %}1 {{ name }} ({{ set|upper }})
 {% endfor %}
 </textarea>

--- a/website/draft_site/drafts/templates/drafts/auto_build.html
+++ b/website/draft_site/drafts/templates/drafts/auto_build.html
@@ -20,9 +20,4 @@ Average card power: {{ avg_power }}
 {% endfor %}
 </div>
 
-<textarea rows="{{ textarea_rows }}">
-{% for name, set in deck_card_names %}1 {{ name }} ({{ set|upper }})
-{% endfor %}
-{% for name, set in leftovers_card_names %}1 {{ name }} ({{ set|upper }})
-{% endfor %}
-</textarea>
+{% include "drafts/deck_exports.html" %}

--- a/website/draft_site/drafts/templates/drafts/deck_exports.html
+++ b/website/draft_site/drafts/templates/drafts/deck_exports.html
@@ -1,0 +1,24 @@
+<table>
+<tr>
+    <td><a href="https://uponthesun.github.io/react-deckbuild-ui/">Deckbuild UI</a></td>
+    <td>Cockatrice</td>
+</tr>
+<tr>
+    <td>
+<textarea rows="{{ textarea_rows }}">
+{% for name, set in deck_card_names %}1 {{ name }} ({{ set|upper }})
+{% endfor %}
+{% for name, set in leftovers_card_names %}1 {{ name }} ({{ set|upper }})
+{% endfor %}
+</textarea>
+    </td>
+    <td>
+<textarea rows="{{ textarea_rows }}">
+{% for name, set in deck_card_names %}1 {{ name }}
+{% endfor %}
+{% for name, set in leftovers_card_names %}1 {{ name }}
+{% endfor %}
+</textarea>
+    </td>
+</tr>
+</table>

--- a/website/draft_site/drafts/templates/drafts/show_seat.html
+++ b/website/draft_site/drafts/templates/drafts/show_seat.html
@@ -48,13 +48,13 @@
 <b>Owned Cards</b>
 
 <div>
-{% for _, image_url in owned_cards %}
+{% for _, image_url, _ in owned_cards %}
     {% if forloop.counter0|divisibleby:draft.cards_per_pack %}<br>{% endif %}
     <img src="{{ image_url }}" class="card" />
 {% endfor %}
 </div>
 
 <textarea rows="{{ owned_cards|length }}">
-{% for card, _ in owned_cards %}1 {{ card.name }}
+{% for card, _, set in owned_cards %}1 {{ card.name }} ({{ set|upper }})
 {% endfor %}
 </textarea>

--- a/website/draft_site/drafts/templates/drafts/show_seat.html
+++ b/website/draft_site/drafts/templates/drafts/show_seat.html
@@ -48,13 +48,10 @@
 <b>Owned Cards</b>
 
 <div>
-{% for _, image_url, _ in owned_cards %}
+{% for _, image_url in owned_cards %}
     {% if forloop.counter0|divisibleby:draft.cards_per_pack %}<br>{% endif %}
     <img src="{{ image_url }}" class="card" />
 {% endfor %}
 </div>
 
-<textarea rows="{{ owned_cards|length }}">
-{% for card, _, set in owned_cards %}1 {{ card.name }} ({{ set|upper }})
-{% endfor %}
-</textarea>
+{% include "drafts/deck_exports.html" %}

--- a/website/draft_site/drafts/views/auto_build.py
+++ b/website/draft_site/drafts/views/auto_build.py
@@ -31,8 +31,8 @@ def auto_build(request, draft_id, seat):
         'seat_range': range(0, draft.num_drafters),  # Used by header
         'built_deck_images': [cube_data.get_image_url(c.name) for c in built_deck],
         'leftovers_images': [cube_data.get_image_url(c.name) for c in leftovers],
-        'deck_card_names': [c.name for c in built_deck],
-        'leftovers_card_names': [c.name for c in leftovers],
+        'deck_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in built_deck],
+        'leftovers_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in leftovers],
         'num_edges': len(deck_graph.edges),
         'avg_power': round(avg_power, 2),
         'textarea_rows': len(pool) + 1,

--- a/website/draft_site/drafts/views/auto_build.py
+++ b/website/draft_site/drafts/views/auto_build.py
@@ -31,10 +31,13 @@ def auto_build(request, draft_id, seat):
         'seat_range': range(0, draft.num_drafters),  # Used by header
         'built_deck_images': [cube_data.get_image_url(c.name) for c in built_deck],
         'leftovers_images': [cube_data.get_image_url(c.name) for c in leftovers],
-        'deck_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in built_deck],
-        'leftovers_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in leftovers],
         'num_edges': len(deck_graph.edges),
         'avg_power': round(avg_power, 2),
+    }
+
+    deck_exports_context = {
+        'deck_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in built_deck],
+        'leftovers_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in leftovers],
         'textarea_rows': len(pool) + 1,
     }
-    return render(request, 'drafts/auto_build.html', context)
+    return render(request, 'drafts/auto_build.html', {**context, **deck_exports_context})

--- a/website/draft_site/drafts/views/show_seat.py
+++ b/website/draft_site/drafts/views/show_seat.py
@@ -34,7 +34,8 @@ def show_seat(request, draft_id, seat):
 
     current_pack_context = {
         'cards': [(c, cube_data.get_image_url(c.name)) for c in current_pack],
-        'owned_cards': [(c, cube_data.get_image_url(c.name)) for c in sorted_owned_cards],
+        'owned_cards': [(c, cube_data.get_image_url(c.name), cube_data.card_by_name(c.name).card_set)
+                        for c in sorted_owned_cards],
         'bot_ratings_column_names': bot_ratings_column_names,
         'bot_ratings_table': bot_ratings_table,
     }

--- a/website/draft_site/drafts/views/show_seat.py
+++ b/website/draft_site/drafts/views/show_seat.py
@@ -34,13 +34,18 @@ def show_seat(request, draft_id, seat):
 
     current_pack_context = {
         'cards': [(c, cube_data.get_image_url(c.name)) for c in current_pack],
-        'owned_cards': [(c, cube_data.get_image_url(c.name), cube_data.card_by_name(c.name).card_set)
-                        for c in sorted_owned_cards],
+        'owned_cards': [(c, cube_data.get_image_url(c.name)) for c in sorted_owned_cards],
         'bot_ratings_column_names': bot_ratings_column_names,
         'bot_ratings_table': bot_ratings_table,
     }
 
-    return render(request, 'drafts/show_seat.html', {**basic_context, **current_pack_context})
+    deck_exports_context = {
+        'deck_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in sorted_owned_cards],
+        'leftovers_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in sorted_owned_cards],
+        'textarea_rows': len(sorted_owned_cards) + 1,
+    }
+
+    return render(request, 'drafts/show_seat.html', {**basic_context, **current_pack_context, **deck_exports_context})
 
 
 def _get_bot_ratings(draft, current_pack, owned_cards):

--- a/website/draft_site/drafts/views/show_seat.py
+++ b/website/draft_site/drafts/views/show_seat.py
@@ -41,7 +41,7 @@ def show_seat(request, draft_id, seat):
 
     deck_exports_context = {
         'deck_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in sorted_owned_cards],
-        'leftovers_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in sorted_owned_cards],
+        'leftovers_card_names': [],
         'textarea_rows': len(sorted_owned_cards) + 1,
     }
 


### PR DESCRIPTION
At the bottom of both the seat overview page and the autobuild page, there are now two textareas:

![image](https://user-images.githubusercontent.com/6564873/92321020-32f4c600-efdb-11ea-95e6-c7a545c65251.png)

The one for the deckbuild UI includes the set names, and the one for cockatrice does not (since unfortunately it doesn't support loading cards from a specific set, somehow).