### PR TITLE
Add some links between pages

### DIFF
--- a/website/draft_site/drafts/templates/drafts/draft_header.html
+++ b/website/draft_site/drafts/templates/drafts/draft_header.html
@@ -1,6 +1,8 @@
 {%load static %}
 <link rel="stylesheet" href="{% static 'general.css' %}" />
 
+<a href="{% url 'show_draft' draft.id%}">Draft Overview</a>
+<br>
 <b>Viewing Seat:</b> {{ drafter.seat }}
 <br>
 {% if drafter.bot %}

--- a/website/draft_site/drafts/templates/drafts/index.html
+++ b/website/draft_site/drafts/templates/drafts/index.html
@@ -1,6 +1,12 @@
 {%load static %}
 <link rel="stylesheet" href="{% static 'general.css' %}" />
 
+<b><a href="{% url 'drafts' %}">Previous drafts</a></b>
+<br>
+<br>
+<b>Start new draft</b>
+<br>
+
 <form action="{% url 'create_draft' %}" method="post">
     {% csrf_token %}
 

--- a/website/draft_site/drafts/templates/drafts/show_draft.html
+++ b/website/draft_site/drafts/templates/drafts/show_draft.html
@@ -1,6 +1,9 @@
 {%load static %}
 <link rel="stylesheet" href="{% static 'general.css' %}" />
 
+<b>{{ cube_name }}</b>
+<br>
+<br>
 <b>Human Drafters</b>
 <br>
 {% for human in human_drafters %}

--- a/website/draft_site/drafts/views/show_draft.py
+++ b/website/draft_site/drafts/views/show_draft.py
@@ -1,16 +1,19 @@
 from django.shortcuts import render, get_object_or_404
 
 from .. import models
+from ..constants import CUBES_BY_ID
 
 
 # /draft/<int:draft_id>
 def show_draft(request, draft_id):
     draft = get_object_or_404(models.Draft, pk=draft_id)
     drafters = draft.drafter_set.all()
+    cube_name = CUBES_BY_ID[draft.cube_id].name
 
     context = {
         'human_drafters': [d for d in drafters if not d.bot],
         'num_bots': len([d for d in drafters if d.bot]),
         'draft': draft,
+        'cube_name': cube_name
     }
     return render(request, 'drafts/show_draft.html', context)


### PR DESCRIPTION
Added:

- Link from homepage to past drafts page (`/drafts`)
- Link from header on seat, autobuild, and review draft pages to draft overview page
- Show cube name on draft overview page