### PR TITLE
Include cards in link to deckbuild UI so user doesn't have to copy-paste

### DIFF
--- a/website/draft_site/drafts/deck_export.py
+++ b/website/draft_site/drafts/deck_export.py
@@ -1,0 +1,23 @@
+import base64
+
+
+def cockatrice(deck, leftovers):
+    deck_lines = [_card_line(c) for c in deck]
+    leftovers_lines = [_card_line(c) for c in leftovers]
+
+    return '\n'.join(deck_lines + [''] + leftovers_lines)
+
+
+def deckbuild_ui(deck, leftovers, cube_data, encoded=False):
+    deck_lines = [_card_line(c, cube_data) for c in deck]
+    leftovers_lines = [_card_line(c, cube_data) for c in leftovers]
+
+    lines = '\n'.join(deck_lines + ['', '// Sideboard'] + leftovers_lines)
+    return base64.urlsafe_b64encode(lines.encode('utf-8')).decode('utf-8') if encoded else lines
+
+
+def _card_line(card, cube_data=None):
+    line = '1 {}'.format(card.name)
+    if cube_data:
+        line += ' ({})'.format(cube_data.card_by_name(card.name).card_set.upper())
+    return line

--- a/website/draft_site/drafts/templates/drafts/deck_exports.html
+++ b/website/draft_site/drafts/templates/drafts/deck_exports.html
@@ -1,25 +1,16 @@
+<br>
+<a href="https://uponthesun.github.io/react-deckbuild-ui/?cards={{ encoded_deckbuild_ui_export }}">Open in deckbuilder</a>
+<br>
+<br>
 <table>
 <tr>
-    <td><a href="https://uponthesun.github.io/react-deckbuild-ui/">Deckbuild UI</a></td>
-    <td>Cockatrice</td>
+    <td>Export to Cockatrice</td>
 </tr>
 <tr>
     <td>
-<textarea rows="{{ textarea_rows }}">
-{% for name, set in deck_card_names %}1 {{ name }} ({{ set|upper }})
-{% endfor %}
-// Sideboard
-{% for name, set in leftovers_card_names %}1 {{ name }} ({{ set|upper }})
-{% endfor %}
-</textarea>
-    </td>
-    <td>
-<textarea rows="{{ textarea_rows }}">
-{% for name, set in deck_card_names %}1 {{ name }}
-{% endfor %}
-{% for name, set in leftovers_card_names %}1 {{ name }}
-{% endfor %}
-</textarea>
+        <textarea rows="{{ textarea_rows }}">
+{{ cockatrice_export }}
+        </textarea>
     </td>
 </tr>
 </table>

--- a/website/draft_site/drafts/views/auto_build.py
+++ b/website/draft_site/drafts/views/auto_build.py
@@ -4,6 +4,7 @@ from django.shortcuts import render, get_object_or_404
 
 from .. import models
 from ..constants import CUBES_BY_ID
+from .. import deck_export
 from mtg_draft_ai.brains import power_rating
 from mtg_draft_ai.deckbuild import best_two_color_synergy_build
 from mtg_draft_ai import synergy
@@ -36,8 +37,8 @@ def auto_build(request, draft_id, seat):
     }
 
     deck_exports_context = {
-        'deck_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in built_deck],
-        'leftovers_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in leftovers],
+        'cockatrice_export': deck_export.cockatrice(built_deck, leftovers),
+        'encoded_deckbuild_ui_export': deck_export.deckbuild_ui(built_deck, leftovers, cube_data, encoded=True),
         'textarea_rows': len(pool) + 1,
     }
     return render(request, 'drafts/auto_build.html', {**context, **deck_exports_context})

--- a/website/draft_site/drafts/views/show_seat.py
+++ b/website/draft_site/drafts/views/show_seat.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, get_object_or_404
 
+from .. import deck_export
 from .. import models
 from ..constants import CUBES_BY_ID
 
@@ -40,8 +41,8 @@ def show_seat(request, draft_id, seat):
     }
 
     deck_exports_context = {
-        'deck_card_names': [(c.name, cube_data.card_by_name(c.name).card_set) for c in sorted_owned_cards],
-        'leftovers_card_names': [],
+        'cockatrice_export': deck_export.cockatrice(sorted_owned_cards, []),
+        'encoded_deckbuild_ui_export': deck_export.deckbuild_ui(sorted_owned_cards, [], cube_data, encoded=True),
         'textarea_rows': len(sorted_owned_cards) + 1,
     }
 


### PR DESCRIPTION
Now, instead of the user having to copy paste the deck contents, the link to the deckbuilding UI includes the deck contents:

<img width="242" alt="image" src="https://user-images.githubusercontent.com/6564873/103477721-49871000-4d76-11eb-85f0-320481b12ba1.png">

[Example Link](https://uponthesun.github.io/react-deckbuild-ui/?cards=MSBNYXVzb2xldW0gV2FuZGVyZXIgKEVNTikKMSBUaHJvYXQgU2xpdHRlciAoQk9LKQoxIEJhc2lsaWNhIFNjcmVlY2hlciAoR1RDKQoxIFNtb2tlIFNocm91ZCAoTUgxKQoxIEF6cmEgU21va2VzaGFwZXIgKE1IMSkKMSBZdXJpa28sIHRoZSBUaWdlcidzIFNoYWRvdyAoQzE4KQoxIE1pc3RibGFkZSBTaGlub2JpIChCT0spCjEgS2l0ZXNhaWwgRnJlZWJvb3RlciAoWExOKQoxIE5pbmphIG9mIHRoZSBEZWVwIEhvdXJzIChCT0spCjEgU2lyZW4gU3Rvcm10YW1lciAoWExOKQoxIFJ1aW4gUmFpZGVyIChYTE4pCjEgU2hhY2tsZWdlaXN0IChNMjEpCjEgU3BlY3RyYWwgU2FpbG9yIChNMjApCjEgVm95YWdlJ3MgRW5kIChUSFMpCjEgQ3J5cHRpYyBTZXJwZW50IChBS0gpCjEgUHRlcmFtYW5kZXIgKFJOQSkKMSBNdXJkZXJvdXMgQ3V0IChLVEspCjEgVWx0aW1hdGUgUHJpY2UgKERUSykKMSBTdXByZW1lIFdpbGwgKEhPVSkKMSBPcHQgKElOVikKMSBPcmRlYWwgb2YgVGhhc3NhIChUSFMpCjEgVXJnZSB0byBGZWVkIChXV0spCjEgSW5kdWxnZW50IEFyaXN0b2NyYXQgKFNPSSkKMSBEcm93bmVkIENhdGFjb21iIChNMTApCgovLyBTaWRlYm9hcmQKMSBBZGVsaXosIHRoZSBDaW5kZXIgV2luZCAoRE9NKQoxIEJsb29kc3BvcmUgVGhyaW5heCAoQzE1KQoxIENsaWZmdG9wIFJldHJlYXQgKElTRCkKMSBKZXNrYWkgQXNjZW5kYW5jeSAoS1RLKQoxIERpc21pc3MgKFRNUCkKMSBDaW5kZXIgQmFycmVucyAoT0dXKQoxIEdvbGdhcmkgU2lnbmV0IChSQVYpCjEgTWFuYSBMZWFrIChTVEgpCjEgSm9yaSBFbiwgUnVpbiBEaXZlciAoRERTKQoxIFBoeXJleGlhbiBSZXZva2VyIChNMTUpCjEgU2FuY3R1bSBTZWVrZXIgKFhMTikKMSBMaXZld2lyZSBMYXNoIChTT00pCjEgUGlhbm5hLCBOb21hZCBDYXB0YWluIChPRFkpCjEgRGVtb3Rpb24gKEdSTikKMSBWZW5nZWZ1bCBSZWJlbCAoQUVSKQoxIEdvYmxpbiBDbGVhcmN1dHRlciAoTEdOKQoxIE1pcmUgVHJpdG9uIChUSEIpCjEgRXhxdWlzaXRlIEh1bnRtYXN0ZXIgKENNUikKMSBBamFuaSdzIFByaWRlbWF0ZSAoTTE5KQoxIE5lY3JvcG9saXMgRmllbmQgKEtUSykKMSBOZWdhdGUgKE0xNCk=)